### PR TITLE
feat: add MCP server package with HTTP transport, OAuth, and advanced…

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "dev:api": "pnpm --filter @sentinel/api dev",
     "dev:worker": "pnpm --filter @sentinel/worker dev",
     "dev:web": "pnpm --filter @sentinel/web dev",
+    "dev:mcp": "pnpm --filter @sentinel/mcp dev",
+    "dev:mcp:http": "pnpm --filter @sentinel/mcp dev:http",
     "build": "pnpm -r build",
     "db:generate": "pnpm --filter @sentinel/db generate",
     "db:migrate": "pnpm --filter @sentinel/db migrate",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -23,13 +23,13 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "drizzle-orm": "^0.38.0",
+    "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.5"
   },
   "devDependencies": {
-    "drizzle-kit": "^0.30.0",
+    "@types/node": "^22.0.0",
+    "drizzle-kit": "^0.31.0",
     "tsx": "^4.19.0",
-    "typescript": "^5.7.0",
-    "@types/node": "^22.0.0"
+    "typescript": "^5.7.0"
   }
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@sentinel/mcp",
+  "version": "0.1.0",
+  "description": "MCP server for Sentinel — query your security monitoring platform with Claude",
+  "type": "module",
+  "bin": {
+    "sentinel-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx watch src/index.ts",
+    "dev:http": "MCP_TRANSPORT=http tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "start:http": "MCP_TRANSPORT=http node dist/index.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.10.2",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "keywords": [
+    "mcp",
+    "sentinel",
+    "security",
+    "monitoring",
+    "claude",
+    "model-context-protocol"
+  ],
+  "license": "MIT"
+}

--- a/packages/mcp/src/auth.ts
+++ b/packages/mcp/src/auth.ts
@@ -1,0 +1,215 @@
+/**
+ * OAuth 2.1 authentication for the Sentinel MCP HTTP transport.
+ *
+ * Two modes:
+ *  1. **Proxy OAuth** — when SENTINEL_OAUTH_ISSUER is set, the MCP server acts as a
+ *     resource server that validates tokens against the upstream Sentinel authorization
+ *     server and proxies all OAuth flows (authorize, token, registration, revocation).
+ *  2. **Simple Bearer** — when only SENTINEL_API_KEY is set (no SENTINEL_OAUTH_ISSUER),
+ *     the middleware validates tokens by forwarding them to the Sentinel API's own
+ *     /api/auth/verify endpoint.
+ *
+ * Both modes use the SDK's `requireBearerAuth()` middleware.
+ */
+import { ProxyOAuthServerProvider } from '@modelcontextprotocol/sdk/server/auth/providers/proxyProvider.js';
+import { requireBearerAuth } from '@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js';
+import { mcpAuthRouter, mcpAuthMetadataRouter, getOAuthProtectedResourceMetadataUrl } from '@modelcontextprotocol/sdk/server/auth/router.js';
+import type { OAuthServerProvider, OAuthTokenVerifier } from '@modelcontextprotocol/sdk/server/auth/provider.js';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import type { OAuthClientInformationFull, OAuthMetadata } from '@modelcontextprotocol/sdk/shared/auth.js';
+import {
+  OAUTH_ISSUER,
+  OAUTH_AUDIENCE,
+  API_URL,
+  API_KEY,
+} from './context.js';
+
+/**
+ * Generic Express-compatible middleware type.
+ * We define this locally to avoid a direct dependency on @types/express,
+ * which is not installed in this project.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Middleware = (...args: any[]) => any;
+
+// ---------------------------------------------------------------------------
+// Token verifier — validates a Bearer token against the Sentinel API
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a token verifier that calls the Sentinel API to validate tokens.
+ *
+ * When a dedicated OAuth issuer is configured, it calls the issuer's introspection endpoint.
+ * Otherwise it falls back to the Sentinel API's own verify endpoint.
+ */
+function createTokenVerifier(introspectionEndpoint?: string): OAuthTokenVerifier {
+  return {
+    async verifyAccessToken(token: string): Promise<AuthInfo> {
+      // If we have an introspection endpoint from the issuer, use it
+      if (introspectionEndpoint) {
+        const res = await fetch(introspectionEndpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({ token }).toString(),
+        });
+
+        if (!res.ok) {
+          const text = await res.text().catch(() => 'unknown error');
+          throw new Error(`Token introspection failed: ${res.status} ${text}`);
+        }
+
+        const data = (await res.json()) as Record<string, unknown>;
+
+        if (data.active === false) {
+          throw new Error('Token is not active');
+        }
+
+        return {
+          token,
+          clientId: (data.client_id as string) ?? 'unknown',
+          scopes: typeof data.scope === 'string' ? (data.scope as string).split(' ') : [],
+          expiresAt: typeof data.exp === 'number' ? (data.exp as number) : undefined,
+        };
+      }
+
+      // Fallback: validate against the Sentinel API itself.
+      // We call a lightweight endpoint that returns the token's session info.
+      const verifyUrl = `${API_URL}/api/auth/verify`;
+      const res = await fetch(verifyUrl, {
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => 'unknown error');
+        throw new Error(`Sentinel token verification failed: ${res.status} ${text}`);
+      }
+
+      const data = (await res.json()) as Record<string, unknown>;
+
+      return {
+        token,
+        clientId: (data.client_id as string) ?? (data.org_id as string) ?? 'sentinel',
+        scopes: Array.isArray(data.scopes) ? (data.scopes as string[]) : ['api:read'],
+        expiresAt: typeof data.exp === 'number' ? (data.exp as number) : undefined,
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public interface
+// ---------------------------------------------------------------------------
+
+export interface AuthSetup {
+  /** Express middleware that validates Bearer tokens on every MCP request. */
+  authMiddleware: Middleware;
+  /** Auth router to mount at app root (OAuth metadata + endpoints). May be null for simple Bearer mode. */
+  authRouter: Middleware | null;
+  /** The OAuth provider instance (for advanced use). */
+  provider: OAuthServerProvider | OAuthTokenVerifier;
+}
+
+/**
+ * Build the auth middleware and (optionally) the OAuth router for the HTTP transport.
+ *
+ * @param mcpServerUrl  The public URL of the MCP HTTP endpoint (e.g. http://localhost:3000/mcp).
+ *                      Used for resource metadata.
+ */
+export function setupAuth(mcpServerUrl: URL): AuthSetup {
+  const resourceMetadataUrl = getOAuthProtectedResourceMetadataUrl(mcpServerUrl);
+
+  // ------------------------------------------------------------------
+  // Mode 1: Full proxy OAuth — SENTINEL_OAUTH_ISSUER is configured
+  // ------------------------------------------------------------------
+  if (OAUTH_ISSUER) {
+    const issuerUrl = new URL(OAUTH_ISSUER);
+
+    // Derive standard endpoints from the issuer URL
+    const authorizationUrl = `${OAUTH_ISSUER}/authorize`;
+    const tokenUrl = `${OAUTH_ISSUER}/token`;
+    const revocationUrl = `${OAUTH_ISSUER}/revoke`;
+    const registrationUrl = `${OAUTH_ISSUER}/register`;
+    const introspectionUrl = `${OAUTH_ISSUER}/introspect`;
+
+    const verifier = createTokenVerifier(introspectionUrl);
+
+    const provider = new ProxyOAuthServerProvider({
+      endpoints: {
+        authorizationUrl,
+        tokenUrl,
+        revocationUrl,
+        registrationUrl,
+      },
+      verifyAccessToken: (token: string) => verifier.verifyAccessToken(token),
+      getClient: async (clientId: string): Promise<OAuthClientInformationFull | undefined> => {
+        // Proxy client lookup to the upstream server
+        try {
+          const res = await fetch(`${OAUTH_ISSUER}/register/${encodeURIComponent(clientId)}`);
+          if (!res.ok) return undefined;
+          return (await res.json()) as OAuthClientInformationFull;
+        } catch {
+          return undefined;
+        }
+      },
+    });
+
+    const authRouter = mcpAuthRouter({
+      provider,
+      issuerUrl,
+      baseUrl: mcpServerUrl,
+      serviceDocumentationUrl: new URL(`${API_URL}/docs`),
+      scopesSupported: ['api:read', 'api:write'],
+      resourceServerUrl: mcpServerUrl,
+      resourceName: 'Sentinel MCP Server',
+    });
+
+    const authMiddleware = requireBearerAuth({
+      verifier: provider,
+      requiredScopes: [],
+      resourceMetadataUrl,
+    });
+
+    return { authMiddleware, authRouter, provider };
+  }
+
+  // ------------------------------------------------------------------
+  // Mode 2: Simple Bearer — validate tokens against Sentinel API
+  // ------------------------------------------------------------------
+  const verifier = createTokenVerifier();
+
+  // In simple Bearer mode, we still advertise resource metadata so MCP
+  // clients know they need a token, but we skip the full OAuth router.
+  const authMiddleware = requireBearerAuth({
+    verifier,
+    requiredScopes: [],
+    resourceMetadataUrl,
+  });
+
+  // No full OAuth router in simple mode — clients supply a pre-existing token.
+  // But we do want to serve protected resource metadata so clients can discover
+  // that auth is required.
+  let metadataRouter: Middleware | null = null;
+
+  if (OAUTH_AUDIENCE) {
+    // Build a minimal OAuth metadata object pointing clients to the Sentinel API
+    const oauthMetadata: OAuthMetadata = {
+      issuer: API_URL,
+      authorization_endpoint: `${API_URL}/oauth/authorize`,
+      token_endpoint: `${API_URL}/oauth/token`,
+      response_types_supported: ['code'],
+      code_challenge_methods_supported: ['S256'],
+    };
+
+    metadataRouter = mcpAuthMetadataRouter({
+      oauthMetadata,
+      resourceServerUrl: mcpServerUrl,
+      scopesSupported: ['api:read', 'api:write'],
+      resourceName: 'Sentinel MCP Server',
+    }) as Middleware;
+  }
+
+  return { authMiddleware, authRouter: metadataRouter, provider: verifier };
+}

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -1,0 +1,110 @@
+/**
+ * Thin HTTP client for the Sentinel API.
+ * Handles auth headers, query string building, and error normalization.
+ */
+import { API_URL, API_KEY } from './context.js';
+
+class ApiError extends Error {
+  constructor(public status: number, message: string) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+function buildQuery(params: Record<string, unknown>): string {
+  const entries: string[] = [];
+  for (const [k, v] of Object.entries(params)) {
+    if (v === undefined || v === null) continue;
+    if (Array.isArray(v)) {
+      for (const item of v) entries.push(`${encodeURIComponent(k)}=${encodeURIComponent(String(item))}`);
+    } else {
+      entries.push(`${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`);
+    }
+  }
+  return entries.length > 0 ? `?${entries.join('&')}` : '';
+}
+
+const baseHeaders: Record<string, string> = {
+  'Content-Type': 'application/json',
+  // Bypass CSRF check for Bearer token requests (handled in API middleware)
+};
+
+// API_KEY may be empty when running in HTTP transport with OAuth —
+// in that case, the auth middleware on the MCP side handles authentication,
+// and per-request tokens could be forwarded. For now, if a key is configured
+// we always send it.
+if (API_KEY) {
+  baseHeaders['Authorization'] = `Bearer ${API_KEY}`;
+}
+
+export async function apiGet(path: string, params: Record<string, unknown> = {}): Promise<unknown> {
+  const url = `${API_URL}${path}${buildQuery(params)}`;
+  const res = await fetch(url, { headers: baseHeaders });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new ApiError(res.status, `GET ${path} → ${res.status}: ${body}`);
+  }
+  return res.json();
+}
+
+export async function apiPost(path: string, body: unknown): Promise<unknown> {
+  const url = `${API_URL}${path}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: baseHeaders,
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new ApiError(res.status, `POST ${path} → ${res.status}: ${text}`);
+  }
+  return res.json();
+}
+
+export async function apiPatch(path: string, body: unknown): Promise<unknown> {
+  const url = `${API_URL}${path}`;
+  const res = await fetch(url, {
+    method: 'PATCH',
+    headers: baseHeaders,
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new ApiError(res.status, `PATCH ${path} → ${res.status}: ${text}`);
+  }
+  return res.json();
+}
+
+export async function apiDelete(path: string): Promise<unknown> {
+  const url = `${API_URL}${path}`;
+  const res = await fetch(url, { method: 'DELETE', headers: baseHeaders });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new ApiError(res.status, `DELETE ${path} → ${res.status}: ${text}`);
+  }
+  return res.json();
+}
+
+/** Wrap an API call, returning { error } on failure instead of throwing. */
+export async function safe(fn: () => Promise<unknown>): Promise<unknown> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof ApiError) {
+      return { error: err.message, status: err.status };
+    }
+    return { error: String(err) };
+  }
+}
+
+export function ok(data: unknown): { content: [{ type: 'text'; text: string }] } {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+}
+
+/** Return structured content for tools that declare an outputSchema. */
+export function structured(data: Record<string, unknown>): { structuredContent: Record<string, unknown>; content: [{ type: 'text'; text: string }] } {
+  return {
+    structuredContent: data,
+    content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+  };
+}

--- a/packages/mcp/src/context.ts
+++ b/packages/mcp/src/context.ts
@@ -1,0 +1,56 @@
+/**
+ * MCP server context — configuration from environment variables.
+ *
+ * The MCP server is a thin HTTP client over the Sentinel API.
+ * This gives us: multi-tenancy (auth scopes to org), audit logging, rate limiting.
+ *
+ * Required env vars:
+ *   SENTINEL_API_URL  — e.g. http://localhost:4000
+ *
+ * Auth — at least one of:
+ *   SENTINEL_API_KEY        — API key with api:read (and api:write for mutations).
+ *                             Required for stdio transport. Optional for HTTP transport
+ *                             when OAuth is configured.
+ *
+ * OAuth 2.1 (HTTP transport only):
+ *   SENTINEL_OAUTH_ISSUER   — OAuth authorization server URL (e.g. https://auth.sentinel.example.com).
+ *                             When set, the MCP HTTP transport uses full proxy OAuth 2.1 + PKCE.
+ *   SENTINEL_OAUTH_AUDIENCE — (optional) The audience / resource identifier for token validation.
+ *
+ * Transport selection:
+ *   MCP_TRANSPORT  — "stdio" (default) or "http"
+ *   MCP_PORT       — HTTP port when using HTTP transport (default: 3000)
+ */
+
+export const API_URL = (process.env.SENTINEL_API_URL ?? 'http://localhost:4000').replace(/\/$/, '');
+
+/** API key — required for stdio transport, optional for HTTP when OAuth is configured. */
+export const API_KEY = process.env.SENTINEL_API_KEY ?? '';
+
+/** OAuth 2.1 issuer URL. When set, enables full OAuth proxy on the HTTP transport. */
+export const OAUTH_ISSUER = process.env.SENTINEL_OAUTH_ISSUER?.replace(/\/$/, '') ?? '';
+
+/** Optional audience / resource identifier for OAuth token validation. */
+export const OAUTH_AUDIENCE = process.env.SENTINEL_OAUTH_AUDIENCE ?? '';
+
+/** Transport mode: "stdio" (default) or "http". */
+export const TRANSPORT = (process.env.MCP_TRANSPORT ?? 'stdio').toLowerCase();
+
+/** HTTP port for the HTTP transport. */
+export const MCP_PORT = parseInt(process.env.MCP_PORT ?? '3000', 10);
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+if (TRANSPORT === 'stdio' && !API_KEY) {
+  process.stderr.write('SENTINEL_API_KEY is required for stdio transport\n');
+  process.exit(1);
+}
+
+if (TRANSPORT === 'http' && !API_KEY && !OAUTH_ISSUER) {
+  process.stderr.write(
+    'HTTP transport requires either SENTINEL_API_KEY or SENTINEL_OAUTH_ISSUER to be set\n',
+  );
+  process.exit(1);
+}

--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -1,0 +1,196 @@
+/**
+ * Streamable HTTP transport for the Sentinel MCP server.
+ *
+ * Features:
+ *   - Stateful sessions (one transport per client session)
+ *   - DNS rebinding protection via Express middleware
+ *   - JSON-RPC over HTTP POST (requests), GET (SSE stream), DELETE (session close)
+ *   - OAuth 2.1 + PKCE when SENTINEL_OAUTH_ISSUER is set
+ *   - Simple Bearer auth fallback when only SENTINEL_API_KEY is set
+ *   - Session cleanup on close
+ */
+import { randomUUID } from 'node:crypto';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { createMcpExpressApp } from '@modelcontextprotocol/sdk/server/express.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { createServer } from './server.js';
+import { API_URL, OAUTH_ISSUER, API_KEY } from './context.js';
+import { setupAuth } from './auth.js';
+
+// ---------------------------------------------------------------------------
+// Config from env
+// ---------------------------------------------------------------------------
+const PORT = parseInt(process.env.MCP_HTTP_PORT ?? '3100', 10);
+const HOST = process.env.MCP_HTTP_HOST ?? '127.0.0.1';
+
+const MCP_PATH = '/mcp';
+
+// ---------------------------------------------------------------------------
+// Session management
+// ---------------------------------------------------------------------------
+const sessions = new Map<string, { transport: StreamableHTTPServerTransport; server: McpServer }>();
+
+// ---------------------------------------------------------------------------
+// HTTP server
+// ---------------------------------------------------------------------------
+export async function startHttpTransport(initialServer: McpServer): Promise<void> {
+  // The initial server instance is used as a factory template — we create
+  // a fresh McpServer per session so tool state doesn't leak between clients.
+  void initialServer; // unused directly; sessions create their own
+
+  // Build Express app with DNS rebinding protection
+  const app = createMcpExpressApp({ host: HOST });
+
+  // ------------------------------------------------------------------
+  // Auth setup — OAuth 2.1 or simple Bearer depending on config
+  // ------------------------------------------------------------------
+  const mcpServerUrl = new URL(`http://${HOST}:${PORT}${MCP_PATH}`);
+  const useAuth = !!(OAUTH_ISSUER || API_KEY);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let authMiddleware: ((...args: any[]) => any) | undefined;
+
+  if (useAuth) {
+    const auth = setupAuth(mcpServerUrl);
+
+    // Mount the OAuth router (metadata + endpoints) at the app root
+    if (auth.authRouter) {
+      app.use(auth.authRouter);
+    }
+
+    authMiddleware = auth.authMiddleware;
+  }
+
+  // ------------------------------------------------------------------
+  // MCP routes
+  // ------------------------------------------------------------------
+
+  // POST /mcp — JSON-RPC requests
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const postHandler = async (req: any, res: any) => {
+    const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+    try {
+      // Existing session
+      if (sessionId && sessions.has(sessionId)) {
+        const session = sessions.get(sessionId)!;
+        await session.transport.handleRequest(req, res, req.body);
+        return;
+      }
+
+      // New initialization request (no session ID)
+      if (!sessionId) {
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => randomUUID(),
+          onsessioninitialized: (sid: string) => {
+            sessions.set(sid, { transport, server: mcpServer });
+          },
+        });
+
+        transport.onclose = () => {
+          const sid = transport.sessionId;
+          if (sid) sessions.delete(sid);
+        };
+
+        const mcpServer = createServer();
+        await mcpServer.connect(transport);
+        await transport.handleRequest(req, res, req.body);
+        return;
+      }
+
+      // Session not found
+      res.status(400).json({
+        jsonrpc: '2.0',
+        error: { code: -32000, message: 'Bad Request: No valid session ID provided' },
+        id: null,
+      });
+    } catch (err) {
+      process.stderr.write(`MCP HTTP POST error: ${err}\n`);
+      if (!res.headersSent) {
+        res.status(500).json({
+          jsonrpc: '2.0',
+          error: { code: -32603, message: 'Internal server error' },
+          id: null,
+        });
+      }
+    }
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const getHandler = async (req: any, res: any) => {
+    const sessionId = req.headers['mcp-session-id'] as string | undefined;
+    if (!sessionId || !sessions.has(sessionId)) {
+      res.status(400).send('Invalid or missing session ID');
+      return;
+    }
+    const session = sessions.get(sessionId)!;
+    await session.transport.handleRequest(req, res);
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const deleteHandler = async (req: any, res: any) => {
+    const sessionId = req.headers['mcp-session-id'] as string | undefined;
+    if (!sessionId || !sessions.has(sessionId)) {
+      res.status(400).send('Invalid or missing session ID');
+      return;
+    }
+    try {
+      const session = sessions.get(sessionId)!;
+      await session.transport.handleRequest(req, res);
+    } catch (err) {
+      process.stderr.write(`MCP HTTP DELETE error: ${err}\n`);
+      if (!res.headersSent) {
+        res.status(500).send('Error processing session termination');
+      }
+    }
+  };
+
+  // Wire up routes with optional auth middleware
+  if (authMiddleware) {
+    app.post(MCP_PATH, authMiddleware, postHandler);
+    app.get(MCP_PATH, authMiddleware, getHandler);
+    app.delete(MCP_PATH, authMiddleware, deleteHandler);
+  } else {
+    app.post(MCP_PATH, postHandler);
+    app.get(MCP_PATH, getHandler);
+    app.delete(MCP_PATH, deleteHandler);
+  }
+
+  // Health check (no auth required)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  app.get('/health', (_req: any, res: any) => {
+    res.json({
+      status: 'ok',
+      api: API_URL,
+      transport: 'http',
+      sessions: sessions.size,
+      auth: OAUTH_ISSUER ? 'oauth' : API_KEY ? 'bearer' : 'none',
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Start listening
+  // ------------------------------------------------------------------
+  app.listen(PORT, HOST, () => {
+    const authMode = OAUTH_ISSUER ? 'OAuth 2.1 (proxy)' : API_KEY ? 'Bearer token' : 'none';
+    process.stderr.write(`Sentinel MCP (Streamable HTTP) listening on http://${HOST}:${PORT}${MCP_PATH}\n`);
+    process.stderr.write(`  Auth: ${authMode}\n`);
+    process.stderr.write(`  Health: http://${HOST}:${PORT}/health\n`);
+  });
+
+  // Graceful shutdown
+  for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+    process.on(signal, async () => {
+      process.stderr.write(`\nShutting down (${signal})...\n`);
+      for (const [, session] of sessions) {
+        try {
+          await session.transport.close();
+        } catch {
+          // ignore cleanup errors
+        }
+      }
+      process.exit(0);
+    });
+  }
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Sentinel MCP Server — entry point
+ *
+ * Transport selection (env: MCP_TRANSPORT):
+ *   "stdio"  (default) — Claude Desktop, CLI pipes.  Requires SENTINEL_API_KEY.
+ *   "http"   — Streamable HTTP with OAuth 2.1 + PKCE or simple Bearer auth.
+ *
+ * See src/context.ts for the full list of env vars.
+ */
+import { TRANSPORT } from './context.js';
+import { createServer } from './server.js';
+
+const transport = TRANSPORT;
+
+if (transport === 'http') {
+  const { startHttpTransport } = await import('./http.js');
+  await startHttpTransport(createServer());
+} else {
+  const { StdioServerTransport } = await import('@modelcontextprotocol/sdk/server/stdio.js');
+  const server = createServer();
+  await server.connect(new StdioServerTransport());
+}

--- a/packages/mcp/src/prompts/index.ts
+++ b/packages/mcp/src/prompts/index.ts
@@ -1,0 +1,168 @@
+/**
+ * MCP Prompts — reusable investigation workflows the agent can invoke by name.
+ */
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+export function registerPrompts(server: McpServer) {
+  server.prompt(
+    'investigate-alert',
+    'Deep-dive investigation of a specific alert: loads alert detail, its detection, correlation rule (if correlated), and synthesizes findings.',
+    { alertId: z.string().describe('Numeric alert ID') },
+    ({ alertId }) => ({
+      messages: [{
+        role: 'user' as const,
+        content: {
+          type: 'text' as const,
+          text: `Investigate alert ${alertId} thoroughly:
+1. Call get-alert with id="${alertId}" to get the full alert, triggerData, and raw event payload.
+2. If it has a detectionId, call get-detection to understand the rule configuration.
+3. If triggerType is "correlated", extract the correlationRuleId from triggerData and call get-correlation-rule.
+4. If there is an eventId, use event-entity-timeline with the key identifier from the event payload to find related activity.
+5. Check list-notification-deliveries for alertId=${alertId} to see if notifications were delivered.
+6. Synthesize: What happened? Which rule fired and why? Is this a true positive? What should be done?`,
+        },
+      }],
+    }),
+  );
+
+  server.prompt(
+    'triage-alert-queue',
+    'Triage the current alert queue: get stats, surface critical/high alerts, cluster by type, and recommend priority order.',
+    {},
+    () => ({
+      messages: [{
+        role: 'user' as const,
+        content: {
+          type: 'text' as const,
+          text: `Triage the current Sentinel alert queue:
+1. Call get-alert-stats to understand the overall volume and severity distribution.
+2. Call list-alerts with severity="critical" and limit=20 to see the most urgent alerts.
+3. Call list-alerts with severity="high" and limit=20 for the next tier.
+4. Group the alerts by module and triggerType. Identify any clusters (multiple alerts from the same detection or entity).
+5. Return a prioritized triage list with: alert ID, title, severity, why it's important, and recommended first action.`,
+        },
+      }],
+    }),
+  );
+
+  server.prompt(
+    'detection-coverage-audit',
+    'Audit detection coverage for a module: identify gaps, redundancies, and recommend templates to add.',
+    { moduleId: z.string().describe('Module to audit: chain | infra | aws | registry | github') },
+    ({ moduleId }) => ({
+      messages: [{
+        role: 'user' as const,
+        content: {
+          type: 'text' as const,
+          text: `Audit detection coverage for the "${moduleId}" module:
+1. Call list-modules-and-event-types to see all event types the module produces.
+2. Call list-detections with moduleId="${moduleId}" to see what's currently monitored.
+3. Call resolve-detection-template with moduleId="${moduleId}" to see available templates.
+4. Compare: which event types have no detection? Which templates aren't deployed? Are any detections paused or disabled?
+5. Return a gap analysis with specific recommendations: which templates to deploy, which detections to review, and any redundancies.`,
+        },
+      }],
+    }),
+  );
+
+  server.prompt(
+    'tune-noisy-detection',
+    'Analyze a noisy detection and suggest tuning: adjust thresholds, add suppressors, or update cooldown.',
+    { detectionId: z.string().uuid().describe('Detection UUID') },
+    ({ detectionId }) => ({
+      messages: [{
+        role: 'user' as const,
+        content: {
+          type: 'text' as const,
+          text: `Tune the noisy detection ${detectionId}:
+1. Call get-detection with id="${detectionId}" to understand the rule configuration.
+2. Call list-alerts with detectionId="${detectionId}" and limit=50 to see recent firing patterns.
+3. If there are recent alerts, call get-event for 3-5 of the eventIds to examine the raw payloads.
+4. Call test-detection with detectionId="${detectionId}" and a sample event to verify the rule behavior.
+5. Based on the patterns, suggest: threshold adjustments, resource scope narrowing (hostScope), cooldown increase, or a suppress rule. Then call update-detection if appropriate.`,
+        },
+      }],
+    }),
+  );
+
+  server.prompt(
+    'write-correlation-rule',
+    'Draft and create a correlation rule from a natural language description.',
+    { description: z.string().describe('What pattern to correlate, e.g. "branch protection disabled then push within 1 hour by same actor"') },
+    ({ description }) => ({
+      messages: [{
+        role: 'user' as const,
+        content: {
+          type: 'text' as const,
+          text: `Create a correlation rule for: "${description}"
+
+Steps:
+1. Call list-modules-and-event-types to understand which modules and event types are relevant.
+2. Call get-sample-event-fields for the relevant moduleId+eventType pairs to see available payload fields.
+3. Draft a CorrelationRuleConfig:
+   - type: "sequence" (for ordered events), "aggregation" (for count thresholds), or "absence" (for missing expected events)
+   - correlationKey: array of {field, alias} entries that link events (e.g. same actor or same repo)
+   - windowMinutes: the time window
+   - steps/aggregation/absence: the specific config for the type
+4. Call create-correlation-rule with the drafted config, a name, and appropriate severity.
+5. Confirm the rule was created and explain what it will detect.`,
+        },
+      }],
+    }),
+  );
+
+  server.prompt(
+    'diagnose-silent-alert',
+    'Diagnose why an expected alert did not fire: check detection health, delivery channels, and test the detection.',
+    {
+      detectionId: z.string().uuid().describe('Detection UUID that should have fired'),
+      expectedTime: z.string().datetime().describe('ISO datetime when the alert was expected'),
+    },
+    ({ detectionId, expectedTime }) => ({
+      messages: [{
+        role: 'user' as const,
+        content: {
+          type: 'text' as const,
+          text: `Diagnose why detection ${detectionId} did not fire around ${expectedTime}:
+1. Call get-detection with id="${detectionId}" — check if status is "active" and cooldown isn't blocking.
+2. Call list-alerts with detectionId="${detectionId}" and a time window around ${expectedTime} — did it actually fire?
+3. Call search-events with moduleId from the detection and a time window around ${expectedTime} — did the events arrive?
+4. If events exist, call test-detection with one of the event IDs to see if it would trigger now.
+5. Call list-notification-deliveries filtered to recent alerts from this detection — were deliveries failing?
+6. Synthesize: Did the event arrive? Did the rule evaluate? Did it fire but notifications failed? Or did no matching event arrive?`,
+        },
+      }],
+    }),
+  );
+
+  server.prompt(
+    'incident-timeline',
+    'Build a full incident timeline for an entity across all Sentinel modules.',
+    {
+      entityId: z.string().describe('Entity identifier: address, hostname, ARN, username, digest, etc.'),
+      from: z.string().datetime().describe('Incident start time (ISO)'),
+      to: z.string().datetime().describe('Incident end time (ISO)'),
+    },
+    ({ entityId, from, to }) => ({
+      messages: [{
+        role: 'user' as const,
+        content: {
+          type: 'text' as const,
+          text: `Build a complete incident timeline for entity: "${entityId}" between ${from} and ${to}
+
+1. Call event-entity-timeline with entity="${entityId}", from="${from}", to="${to}" — this is the primary cross-module signal.
+2. Call list-alerts with from="${from}", to="${to}" and search="${entityId}" — which alerts fired during this window?
+3. For each unique moduleId in the timeline, note what event types appeared and in what order.
+4. Call get-alert for any critical/high alerts in the window to get full triggerData.
+5. Assemble a chronological narrative:
+   - What was observed first?
+   - How did activity progress across modules?
+   - Which detections fired and when?
+   - What is the most likely explanation for the activity?
+   - What follow-up actions are recommended?`,
+        },
+      }],
+    }),
+  );
+}

--- a/packages/mcp/src/resources/index.ts
+++ b/packages/mcp/src/resources/index.ts
@@ -1,0 +1,97 @@
+/**
+ * MCP Resources — URI-addressable data objects the agent can read directly.
+ */
+import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { apiGet, safe } from '../client.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+function toText(data: unknown, uri: string) {
+  return {
+    contents: [{
+      uri,
+      mimeType: 'application/json' as const,
+      text: JSON.stringify(data, null, 2),
+    }],
+  };
+}
+
+export function registerResources(server: McpServer) {
+  // Static resources
+  server.resource(
+    'alert-stats',
+    'sentinel://alerts/stats',
+    { description: 'Live alert statistics: total, today, this week, by severity, 10 most recent' },
+    async (uri) => toText(await safe(() => apiGet('/api/alerts/stats')), uri.href),
+  );
+
+  server.resource(
+    'modules-metadata',
+    'sentinel://modules/metadata',
+    { description: 'All modules, their event types, evaluators, and detection templates' },
+    async (uri) => toText(await safe(() => apiGet('/api/modules/metadata')), uri.href),
+  );
+
+  // Template resources
+  server.resource(
+    'alert-detail',
+    new ResourceTemplate('sentinel://alerts/{id}', { list: undefined }),
+    { description: 'Single alert with triggerData, event payload, and delivery status' },
+    async (uri, variables) => {
+      const id = variables.id as string;
+      return toText(await safe(() => apiGet(`/api/alerts/${id}`)), uri.href);
+    },
+  );
+
+  server.resource(
+    'detection-detail',
+    new ResourceTemplate('sentinel://detections/{id}', { list: undefined }),
+    { description: 'Detection with all rules and full config' },
+    async (uri, variables) => {
+      const id = variables.id as string;
+      return toText(await safe(() => apiGet(`/api/detections/${id}`)), uri.href);
+    },
+  );
+
+  server.resource(
+    'correlation-rule-detail',
+    new ResourceTemplate('sentinel://correlation-rules/{id}', { list: undefined }),
+    { description: 'Correlation rule with full config JSONB' },
+    async (uri, variables) => {
+      const id = variables.id as string;
+      return toText(await safe(() => apiGet(`/api/correlation-rules/${id}`)), uri.href);
+    },
+  );
+
+  server.resource(
+    'correlation-instances',
+    new ResourceTemplate('sentinel://correlation-rules/{id}/instances', { list: undefined }),
+    { description: 'Active in-flight correlation instances from Redis' },
+    async (uri, variables) => {
+      const id = variables.id as string;
+      return toText(await safe(() => apiGet(`/api/correlation-rules/${id}/instances`)), uri.href);
+    },
+  );
+
+  server.resource(
+    'event-detail',
+    new ResourceTemplate('sentinel://events/{id}', { list: undefined }),
+    { description: 'Single event with full JSONB payload' },
+    async (uri, variables) => {
+      const id = variables.id as string;
+      return toText(await safe(() => apiGet(`/api/events/${id}`)), uri.href);
+    },
+  );
+
+  server.resource(
+    'infra-host',
+    new ResourceTemplate('sentinel://infra/hosts/{hostname}', { list: undefined }),
+    { description: 'Full host intelligence: IP, cloud provider, CDN origin, DNS records, last scan' },
+    async (uri, variables) => {
+      const hostname = variables.hostname as string;
+      return toText(
+        await safe(() => apiGet(`/api/infra/hosts/${encodeURIComponent(hostname)}`)),
+        uri.href,
+      );
+    },
+  );
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared MCP server factory.
+ * Creates and configures the McpServer with all tools, resources, and prompts.
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks';
+
+import { registerAlertTools } from './tools/alerts.js';
+import { registerEventTools } from './tools/events.js';
+import { registerDetectionTools } from './tools/detections.js';
+import { registerCorrelationTools } from './tools/correlation.js';
+import { registerNotificationTools } from './tools/notifications.js';
+import { registerModuleTools } from './tools/modules.js';
+import { registerInfraTools } from './tools/infra.js';
+import { registerAwsTools } from './tools/aws.js';
+import { registerChainTools } from './tools/chain.js';
+import { registerRegistryTools } from './tools/registry.js';
+import { registerGithubTools } from './tools/github.js';
+import { registerAuditTools } from './tools/audit.js';
+import { registerResources } from './resources/index.js';
+import { registerPrompts } from './prompts/index.js';
+
+export function createServer(): McpServer {
+  const server = new McpServer(
+    {
+      name: 'sentinel',
+      version: '1.0.0',
+    },
+    {
+      instructions: [
+        'Sentinel is a security monitoring platform. Use these workflows for best results:',
+        '',
+        '## Investigation workflow',
+        '1. Start with `list-alerts` to see recent alerts (filter by severity/status).',
+        '2. Use `get-alert` to inspect a specific alert and read its payload.',
+        '3. Pivot to `search-events` or `entity-timeline` to see what happened around the same entity or time window.',
+        '4. Use `payload-search` for deep JSONB queries when you know the field path.',
+        '5. Use `frequency` to check whether an event pattern is anomalous or routine.',
+        '',
+        '## Detection management',
+        '1. `list-modules-and-event-types` shows available modules, event types, and template slugs.',
+        '2. `resolve-detection-template` shows available templates and their required inputs for a module.',
+        '3. `test-detection` dry-runs a detection against a real or inline event — always test before enabling.',
+        '4. `create-detection-from-template` creates a detection with rules from a template.',
+        '5. `update-detection` changes severity, status (active/paused/disabled), or cooldown.',
+        '',
+        '## Infrastructure monitoring',
+        '1. `infra-list-hosts` → `infra-lookup-host` for full host intelligence (IP, ASN, ports, CDN).',
+        '2. `infra-dns-history` and `infra-cert-expiry-report` for DNS/TLS hygiene.',
+        '3. `infra-security-score` for a composite score with category breakdown.',
+        '4. `infra-trigger-scan` to force an immediate rescan of a host.',
+        '',
+        '## Correlation rules',
+        'Use correlation rules when you need to detect patterns across multiple events:',
+        '- **Sequence**: ordered steps that must occur within a time window (e.g., login → privilege escalation → data export).',
+        '- **Aggregation**: threshold-based (e.g., >10 failed logins in 5 minutes for the same principal).',
+        '- **Absence**: alert when an expected event does NOT occur within a window.',
+        'Always use `get-correlation-instances` to inspect in-flight state before clearing.',
+      ].join('\n'),
+      // Enable experimental task support for long-running operations
+      capabilities: {
+        tasks: {
+          requests: { tools: { call: {} } },
+        },
+      },
+      taskStore: new InMemoryTaskStore(),
+    },
+  );
+
+  // Register all tools (65 total)
+  registerAlertTools(server);       // 3  — list-alerts, get-alert, get-alert-stats
+  registerEventTools(server);       // 5  — search-events, get-event, entity-timeline, payload-search, frequency
+  registerDetectionTools(server);   // 5  — list, get, test, create-from-template, update
+  registerCorrelationTools(server); // 6  — list, get, create, update, get-instances, clear-instances
+  registerNotificationTools(server); // 7 — list-deliveries, delivery-stats, list/get/create/update-channel, test-channel
+  registerModuleTools(server);      // 4  — list-modules, get-sample-fields, resolve-template, browse-field-catalog
+  registerInfraTools(server);       // 10 — list-hosts, lookup, origin, dns-history, cert-expiry, tls, whois, score, add-host, trigger-scan
+  registerAwsTools(server);         // 6  — query-events, principal-activity, resource-history, error-patterns, top-actors, account-summary
+  registerChainTools(server);       // 7  — address-activity, balance-history, state-history, network-status, rpc-usage, add-contract, discover-storage
+  registerRegistryTools(server);    // 7  — artifact-summary, digest-history, attribution-report, unsigned-releases, ci-notifications, add-image, add-package
+  registerGithubTools(server);      // 4  — repo-activity, actor-activity, installations, repos
+  registerAuditTools(server);       // 1  — query-audit-log
+
+  // Register URI resources
+  registerResources(server);
+
+  // Register investigation prompts
+  registerPrompts(server);
+
+  return server;
+}

--- a/packages/mcp/src/tools/alerts.ts
+++ b/packages/mcp/src/tools/alerts.ts
@@ -1,0 +1,122 @@
+import { z } from 'zod';
+import { apiGet, safe, ok, structured } from '../client.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+// --- Shared output schemas ---
+
+const AlertSummary = z.object({
+  id: z.number(),
+  severity: z.enum(['critical', 'high', 'medium', 'low']),
+  title: z.string(),
+  description: z.string().nullable(),
+  triggerType: z.string(),
+  notificationStatus: z.string(),
+  createdAt: z.string(),
+  detectionId: z.string().nullable(),
+  ruleId: z.string().nullable(),
+  eventId: z.string().nullable(),
+  detectionName: z.string().nullable(),
+  moduleId: z.string().nullable(),
+});
+
+const PaginationMeta = z.object({
+  page: z.number(),
+  limit: z.number(),
+  total: z.number(),
+  totalPages: z.number(),
+});
+
+export function registerAlertTools(server: McpServer) {
+  server.registerTool(
+    'list-alerts',
+    {
+      description: 'List alerts with optional filters: severity, moduleId, detectionId, triggerType, search (title+description), date range, pagination.',
+      inputSchema: {
+        detectionId: z.string().uuid().optional(),
+        moduleId: z.string().optional(),
+        severity: z.enum(['critical', 'high', 'medium', 'low']).optional(),
+        triggerType: z.string().optional().describe('direct | correlated'),
+        search: z.string().max(255).optional(),
+        from: z.string().datetime().optional(),
+        to: z.string().datetime().optional(),
+        page: z.number().int().positive().default(1),
+        limit: z.number().int().positive().max(100).default(20),
+      },
+      outputSchema: {
+        data: z.array(AlertSummary),
+        meta: PaginationMeta,
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    },
+    async (params) => {
+      const result = await safe(() => apiGet('/api/alerts', params));
+      return structured(result as Record<string, unknown>);
+    },
+  );
+
+  server.registerTool(
+    'get-alert',
+    {
+      description: 'Get a single alert by ID with full triggerData, raw event payload, and notification delivery status.',
+      inputSchema: { id: z.string().describe('Alert ID (numeric)') },
+      outputSchema: {
+        data: z.object({
+          id: z.number(),
+          orgId: z.string(),
+          detectionId: z.string().nullable(),
+          ruleId: z.string().nullable(),
+          eventId: z.string().nullable(),
+          severity: z.enum(['critical', 'high', 'medium', 'low']),
+          title: z.string(),
+          description: z.string().nullable(),
+          triggerType: z.string(),
+          triggerData: z.record(z.string(), z.unknown()),
+          notificationStatus: z.string(),
+          notifications: z.array(z.unknown()),
+          createdAt: z.string(),
+          detectionName: z.string().nullable(),
+          event: z.object({
+            id: z.string(),
+            moduleId: z.string(),
+            eventType: z.string(),
+            externalId: z.string().nullable(),
+            payload: z.record(z.string(), z.unknown()),
+            occurredAt: z.string(),
+            receivedAt: z.string(),
+          }).nullable(),
+        }),
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    },
+    async ({ id }) => {
+      const result = await safe(() => apiGet(`/api/alerts/${id}`));
+      return structured(result as Record<string, unknown>);
+    },
+  );
+
+  server.registerTool(
+    'get-alert-stats',
+    {
+      description: 'Alert statistics: total, today, this week, active detections, breakdown by severity, 10 most recent.',
+      outputSchema: {
+        total: z.number(),
+        today: z.number(),
+        thisWeek: z.number(),
+        activeDetections: z.number(),
+        bySeverity: z.record(z.string(), z.number()),
+        recent: z.array(z.object({
+          id: z.number(),
+          severity: z.string(),
+          title: z.string(),
+          createdAt: z.string(),
+          detectionName: z.string().nullable(),
+        })),
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    },
+    async () => {
+      const result = await safe(() => apiGet('/api/alerts/stats'));
+      return structured(result as Record<string, unknown>);
+    },
+  );
+}

--- a/packages/mcp/src/tools/audit.ts
+++ b/packages/mcp/src/tools/audit.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+import { apiGet, safe, ok } from '../client.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+export function registerAuditTools(server: McpServer) {
+  server.tool(
+    'query-audit-log',
+    'Query the org audit log. Filter by action, resource type, user, or date range. Shows who changed what and when.',
+    {
+      action: z.string().max(255).optional().describe('e.g. "channel.create", "detection.update"'),
+      resourceType: z.string().max(255).optional().describe('e.g. "channel", "detection", "correlation_rule"'),
+      userId: z.string().uuid().optional(),
+      since: z.string().datetime().optional(),
+      until: z.string().datetime().optional(),
+      limit: z.number().int().min(1).max(100).default(50),
+      offset: z.number().int().min(0).default(0),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/audit-log', params))),
+  );
+}

--- a/packages/mcp/src/tools/aws.ts
+++ b/packages/mcp/src/tools/aws.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod';
+import { apiGet, safe, ok } from '../client.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+export function registerAwsTools(server: McpServer) {
+  server.tool(
+    'aws-query-events',
+    'Query raw CloudTrail events. Filter by eventName, eventSource, principalId, resourceArn (JSONB containment), region, errorCode, date range. Answers "who pushed to S3 recently?"',
+    {
+      eventName: z.string().optional().describe('e.g. "PutObject", "CreateUser"'),
+      eventSource: z.string().optional().describe('e.g. "s3.amazonaws.com", "iam.amazonaws.com"'),
+      principalId: z.string().optional(),
+      resourceArn: z.string().optional().describe('Full ARN — uses JSONB containment query'),
+      region: z.string().optional(),
+      errorCode: z.string().optional(),
+      from: z.string().datetime().optional(),
+      to: z.string().datetime().optional(),
+      limit: z.number().int().positive().max(200).default(50),
+      page: z.number().int().positive().default(1),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
+    async (params) => ok(await safe(() => apiGet('/api/aws/events', params))),
+  );
+
+  server.tool(
+    'aws-principal-activity',
+    'All CloudTrail actions by a principal. Returns a timeline plus a grouped summary by eventName+errorCode.',
+    {
+      principalId: z.string(),
+      from: z.string().datetime().optional(),
+      to: z.string().datetime().optional(),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async ({ principalId, ...params }) => ok(await safe(() => apiGet(`/api/aws/principal/${encodeURIComponent(principalId)}/activity`, params))),
+  );
+
+  server.tool(
+    'aws-resource-history',
+    'All CloudTrail events that touched a specific resource ARN. Shows who did what to this resource and when.',
+    {
+      resourceArn: z.string().describe('Full AWS ARN of the resource'),
+      from: z.string().datetime().optional(),
+      to: z.string().datetime().optional(),
+      limit: z.number().int().positive().max(200).default(50),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/aws/resource-history', params))),
+  );
+
+  server.tool(
+    'aws-error-patterns',
+    'Systematic access denial patterns: groups errors by principalId + eventName + errorCode. Surfaces IAM misconfiguration or enumeration attempts.',
+    {
+      from: z.string().datetime().optional(),
+      to: z.string().datetime().optional(),
+      limit: z.number().int().positive().max(100).default(20),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/aws/error-patterns', params))),
+  );
+
+  server.tool(
+    'aws-top-actors',
+    'Most active AWS principals by event count. Useful for identifying unusually active accounts.',
+    {
+      from: z.string().datetime().optional(),
+      to: z.string().datetime().optional(),
+      limit: z.number().int().positive().max(50).default(20),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/aws/top-actors', params))),
+  );
+
+  server.tool(
+    'aws-account-summary',
+    'AWS integration health: account IDs, monitored regions, last poll times, and any error states.',
+    {},
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async () => ok(await safe(() => apiGet('/api/aws/integrations/summary'))),
+  );
+}

--- a/packages/mcp/src/tools/chain.ts
+++ b/packages/mcp/src/tools/chain.ts
@@ -1,0 +1,130 @@
+import { z } from 'zod';
+import { apiGet, apiPost, safe, ok } from '../client.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+export function registerChainTools(server: McpServer) {
+  server.tool(
+    'chain-address-activity',
+    'All on-chain events for an address across all monitored networks. Answers "what has happened with 0xabc... recently?"',
+    {
+      address: z.string().describe('Ethereum address (0x...)'),
+      networkId: z.number().int().optional(),
+      from: z.string().datetime().optional(),
+      to: z.string().datetime().optional(),
+      limit: z.number().int().positive().max(200).default(50),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/chain/address-activity', params))),
+  );
+
+  server.tool(
+    'chain-balance-history',
+    'Balance snapshot history for a tracked address/rule. Shows value changes over time with block numbers.',
+    {
+      ruleId: z.string().uuid().optional(),
+      address: z.string().optional(),
+      networkId: z.number().int().optional(),
+      limit: z.number().int().positive().max(500).default(100),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/chain/balance-history', params))),
+  );
+
+  server.tool(
+    'chain-state-history',
+    'Storage slot value timeline for a contract. Shows how a specific storage slot changed over time.',
+    {
+      ruleId: z.string().uuid().optional(),
+      address: z.string().optional(),
+      slot: z.string().optional().describe('Storage slot identifier'),
+      limit: z.number().int().positive().max(500).default(100),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/chain/state-history', params))),
+  );
+
+  server.tool(
+    'chain-network-status',
+    'Block cursor positions per network — shows the last polled block for each chain. Use to check if pollers are healthy or behind.',
+    {},
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async () => ok(await safe(() => apiGet('/api/chain/network-status'))),
+  );
+
+  server.tool(
+    'chain-rpc-usage',
+    'Hourly RPC call counts by network, template, and method. Useful for cost monitoring and identifying high-frequency polling rules.',
+    {
+      networkId: z.number().int().optional(),
+      since: z.string().datetime().optional(),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/chain/rpc-usage', params))),
+  );
+
+  server.tool(
+    'chain-add-contract',
+    'Add a smart contract for monitoring. Provide network slug, address, and label. Optionally pass an ABI or set fetchAbi to auto-fetch from block explorer.',
+    {
+      networkSlug: z.string().min(1).describe('Network slug, e.g. "ethereum", "arbitrum"'),
+      address: z.string().regex(/^0x[a-fA-F0-9]{40}$/).describe('Contract address (0x...)'),
+      label: z.string().min(1),
+      tags: z.array(z.string()).default([]),
+      notes: z.string().optional(),
+      abi: z.unknown().optional().describe('Contract ABI JSON (optional)'),
+      fetchAbi: z.boolean().default(false).describe('Auto-fetch ABI from block explorer'),
+    },
+    { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    async (body) => ok(await safe(() => apiPost('/api/chain/contracts', body))),
+  );
+
+  server.tool(
+    'chain-discover-storage',
+    'Trigger storage layout discovery for a monitored contract. Analyzes storage slots for state-watching rules.',
+    { contractId: z.number().int().describe('Contract ID (numeric)') },
+    { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    async ({ contractId }) => ok(await safe(() => apiPost(`/api/chain/contracts/${contractId}/analyze-storage`, {}))),
+  );
+
+  // --- Experimental: task-based variant of chain-discover-storage ---
+  server.experimental.tasks.registerToolTask(
+    'chain-discover-storage-task',
+    {
+      description:
+        'Long-running variant of chain-discover-storage. Triggers storage layout discovery and polls until the analysis completes.',
+      inputSchema: { contractId: z.number().int().describe('Contract ID (numeric)') },
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+      execution: { taskSupport: 'required' },
+    },
+    {
+      createTask: async ({ contractId }, extra) => {
+        const task = await extra.taskStore.createTask({ ttl: 300_000, pollInterval: 5_000 });
+
+        (async () => {
+          try {
+            const result = await safe(() =>
+              apiPost(`/api/chain/contracts/${contractId}/analyze-storage`, {}),
+            );
+            await extra.taskStore.storeTaskResult(task.taskId, 'completed', {
+              content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+            });
+          } catch (err) {
+            await extra.taskStore.storeTaskResult(task.taskId, 'failed', {
+              content: [{ type: 'text' as const, text: `Storage discovery failed: ${String(err)}` }],
+              isError: true,
+            });
+          }
+        })();
+
+        return { task };
+      },
+      getTask: async (_args, extra) => {
+        return await extra.taskStore.getTask(extra.taskId);
+      },
+      getTaskResult: async (_args, extra) => {
+        return (await extra.taskStore.getTaskResult(extra.taskId)) as CallToolResult;
+      },
+    },
+  );
+}

--- a/packages/mcp/src/tools/correlation.ts
+++ b/packages/mcp/src/tools/correlation.ts
@@ -1,0 +1,101 @@
+import { z } from 'zod';
+import { apiGet, apiPost, apiPatch, apiDelete, safe, ok } from '../client.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+export function registerCorrelationTools(server: McpServer) {
+  server.tool(
+    'list-correlation-rules',
+    'List all correlation rules for the org.',
+    { status: z.enum(['active', 'paused']).optional() },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/correlation-rules', params))),
+  );
+
+  server.tool(
+    'get-correlation-rule',
+    'Get a single correlation rule by ID with full config (type, correlationKey, windowMinutes, steps/aggregation/absence).',
+    { id: z.string().uuid() },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async ({ id }) => ok(await safe(() => apiGet(`/api/correlation-rules/${id}`))),
+  );
+
+  server.tool(
+    'create-correlation-rule',
+    'Create a new correlation rule. Config must be a CorrelationRuleConfig object with type ("sequence"|"aggregation"|"absence"), correlationKey, windowMinutes, and the appropriate steps/aggregation/absence field.',
+    {
+      name: z.string().min(1),
+      description: z.string().optional(),
+      severity: z.enum(['critical', 'high', 'medium', 'low']).default('high'),
+      config: z.record(z.string(), z.unknown()).describe('CorrelationRuleConfig JSONB'),
+      channelIds: z.array(z.string().uuid()).default([]),
+      cooldownMinutes: z.number().int().min(0).default(0),
+    },
+    { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    async (body) => ok(await safe(() => apiPost('/api/correlation-rules', body))),
+  );
+
+  server.tool(
+    'update-correlation-rule',
+    'Update a correlation rule: name, description, severity, status, config, channelIds, or cooldownMinutes.',
+    {
+      id: z.string().uuid(),
+      name: z.string().optional(),
+      description: z.string().optional(),
+      severity: z.enum(['critical', 'high', 'medium', 'low']).optional(),
+      status: z.enum(['active', 'paused']).optional(),
+      config: z.record(z.string(), z.unknown()).optional(),
+      channelIds: z.array(z.string().uuid()).optional(),
+      cooldownMinutes: z.number().int().min(0).optional(),
+    },
+    { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    async ({ id, ...body }) => ok(await safe(() => apiPatch(`/api/correlation-rules/${id}`, body))),
+  );
+
+  server.tool(
+    'get-correlation-instances',
+    'List active in-flight correlation instances from Redis for a given rule. Shows which key groups are currently being tracked in the correlation window.',
+    { id: z.string().uuid().describe('Correlation rule UUID') },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async ({ id }) => ok(await safe(() => apiGet(`/api/correlation-rules/${id}/instances`))),
+  );
+
+  server.tool(
+    'clear-correlation-instances',
+    'DESTRUCTIVE: Clear all active correlation instances for a rule from Redis. Resets in-flight sequence/aggregation tracking. Use only for debugging or rule resets.',
+    {
+      id: z.string().uuid().describe('Correlation rule UUID'),
+      confirm: z.literal(true).describe('Must be true to confirm this destructive operation'),
+    },
+    { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false },
+    async ({ id }) => {
+      // Elicitation: ask user to confirm destructive action before executing
+      try {
+        const elicitResult = await server.server.elicitInput({
+          mode: 'form',
+          message: `You are about to clear ALL active correlation instances for rule ${id}. This resets in-flight sequence/aggregation tracking and cannot be undone. Are you sure?`,
+          requestedSchema: {
+            type: 'object',
+            properties: {
+              confirm: {
+                type: 'boolean',
+                title: 'Confirm deletion',
+                description: 'Set to true to proceed with clearing all instances',
+              },
+            },
+            required: ['confirm'],
+          },
+        });
+
+        if (elicitResult.action !== 'accept' || !elicitResult.content?.confirm) {
+          return ok({ cancelled: true, message: 'Operation cancelled by user.' });
+        }
+      } catch {
+        // Elicitation not supported by this client/transport — fall through
+        // and rely on the `confirm: true` parameter as the existing guard.
+      }
+
+      return ok(await safe(() => apiDelete(`/api/correlation-rules/${id}/instances`)));
+    },
+  );
+
+}

--- a/packages/mcp/src/tools/detections.ts
+++ b/packages/mcp/src/tools/detections.ts
@@ -1,0 +1,103 @@
+import { z } from 'zod';
+import { apiGet, apiPost, apiPatch, safe, ok, structured } from '../client.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+export function registerDetectionTools(server: McpServer) {
+  server.registerTool(
+    'list-detections',
+    {
+      description: 'List detections with optional filters by module, status, severity, or name search. Includes rule count per detection.',
+      inputSchema: {
+        moduleId: z.string().optional(),
+        status: z.enum(['active', 'paused', 'disabled']).optional(),
+        severity: z.enum(['critical', 'high', 'medium', 'low']).optional(),
+        search: z.string().max(255).optional(),
+        page: z.number().int().positive().default(1),
+        limit: z.number().int().positive().max(100).default(20),
+      },
+      outputSchema: {
+        data: z.array(z.object({
+          id: z.string(),
+          moduleId: z.string(),
+          templateId: z.string().nullable(),
+          name: z.string(),
+          description: z.string().nullable(),
+          severity: z.enum(['critical', 'high', 'medium', 'low']),
+          status: z.string(),
+          cooldownMinutes: z.number(),
+          lastTriggeredAt: z.string().nullable(),
+          createdAt: z.string(),
+          updatedAt: z.string(),
+          ruleCount: z.number(),
+        })),
+        meta: z.object({
+          page: z.number(),
+          limit: z.number(),
+          total: z.number(),
+          totalPages: z.number(),
+        }),
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    },
+    async (params) => {
+      const result = await safe(() => apiGet('/api/detections', params));
+      return structured(result as Record<string, unknown>);
+    },
+  );
+
+  server.tool(
+    'get-detection',
+    'Get a detection by ID including all its rules with full config JSONB.',
+    { id: z.string().uuid() },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async ({ id }) => ok(await safe(() => apiGet(`/api/detections/${id}`))),
+  );
+
+  server.tool(
+    'test-detection',
+    'Dry-run a detection against a test event without side effects. Provide eventId to load from DB, or an inline event object. Returns wouldTrigger, suppressed, candidates, rulesEvaluated.',
+    {
+      detectionId: z.string().uuid(),
+      eventId: z.string().uuid().optional().describe('Load an existing event from DB by UUID'),
+      event: z.object({
+        eventType: z.string(),
+        payload: z.record(z.string(), z.unknown()),
+      }).optional().describe('Inline event to test with'),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async ({ detectionId, eventId, event }) => {
+      return ok(await safe(() => apiPost(`/api/detections/${detectionId}/test`, { eventId, event })));
+    },
+  );
+
+  server.tool(
+    'create-detection-from-template',
+    'Create a detection from a module template slug. Resolves the template, inserts the detection and rules.',
+    {
+      moduleId: z.string().describe('chain | infra | aws | registry | github'),
+      templateSlug: z.string().describe('Template slug, e.g. "balance-threshold", "digest-change"'),
+      name: z.string().optional().describe('Override the template name'),
+      severity: z.enum(['critical', 'high', 'medium', 'low']).optional(),
+      inputs: z.record(z.string(), z.unknown()).default({}).describe('Template input parameters'),
+      channelIds: z.array(z.string().uuid()).default([]),
+    },
+    { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    async (body) => ok(await safe(() => apiPost('/api/detections', body))),
+  );
+
+  server.tool(
+    'update-detection',
+    'Update a detection: name, description, severity, cooldown minutes, or status.',
+    {
+      id: z.string().uuid(),
+      name: z.string().optional(),
+      description: z.string().optional(),
+      severity: z.enum(['critical', 'high', 'medium', 'low']).optional(),
+      status: z.enum(['active', 'paused', 'disabled']).optional(),
+      cooldownMinutes: z.number().int().min(0).optional(),
+    },
+    { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    async ({ id, ...body }) => ok(await safe(() => apiPatch(`/api/detections/${id}`, body))),
+  );
+
+}

--- a/packages/mcp/src/tools/events.ts
+++ b/packages/mcp/src/tools/events.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod';
+import { apiGet, safe, ok, structured } from '../client.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+export function registerEventTools(server: McpServer) {
+  server.tool(
+    'search-events',
+    'Search events by moduleId, eventType, full-text search across externalId+eventType+payload, and date range.',
+    {
+      moduleId: z.string().optional(),
+      eventType: z.string().optional(),
+      search: z.string().max(255).optional(),
+      from: z.string().datetime().optional(),
+      to: z.string().datetime().optional(),
+      page: z.number().int().positive().default(1),
+      limit: z.number().int().positive().max(100).default(20),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
+    async (params) => ok(await safe(() => apiGet('/api/events', params))),
+  );
+
+  server.tool(
+    'get-event',
+    'Get a single event by UUID with full payload.',
+    { id: z.string().uuid() },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async ({ id }) => ok(await safe(() => apiGet(`/api/events/${id}`))),
+  );
+
+  server.registerTool(
+    'event-entity-timeline',
+    {
+      description: 'THE killer tool: given any identifier (address, ARN, hostname, username, digest, repo name, IP...), searches all event payloads across every module and returns a chronological timeline. Use to answer "what does Sentinel know about X?"',
+      inputSchema: {
+        entity: z.string().describe('Any identifier to search for across all event payloads'),
+        from: z.string().datetime().optional(),
+        to: z.string().datetime().optional(),
+        limit: z.number().int().positive().max(500).default(100),
+      },
+      outputSchema: {
+        entity: z.string(),
+        count: z.number(),
+        data: z.array(z.object({
+          id: z.string(),
+          moduleId: z.string(),
+          eventType: z.string(),
+          externalId: z.string().nullable(),
+          occurredAt: z.string(),
+          receivedAt: z.string(),
+          payload: z.record(z.string(), z.unknown()),
+        })),
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
+    },
+    async (params) => {
+      const result = await safe(() => apiGet('/api/events/timeline', params));
+      return structured(result as Record<string, unknown>);
+    },
+  );
+
+  server.tool(
+    'event-search-payload',
+    'Search events by a specific JSONB payload field value. Use dot-notation for nested fields (e.g. "sender.login", "repository.full_name", "principalId").',
+    {
+      field: z.string().describe('Dot-notation JSON path in payload, e.g. "address", "sender.login"'),
+      value: z.string(),
+      moduleId: z.string().optional(),
+      eventType: z.string().optional(),
+      from: z.string().datetime().optional(),
+      to: z.string().datetime().optional(),
+      limit: z.number().int().positive().max(100).default(20),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
+    async (params) => ok(await safe(() => apiGet('/api/events/payload-search', params))),
+  );
+
+  server.tool(
+    'event-frequency',
+    'Daily event counts grouped by moduleId and eventType. Useful for detecting volume spikes or unusual activity patterns.',
+    {
+      moduleId: z.string().optional(),
+      eventType: z.string().optional(),
+      from: z.string().datetime().optional(),
+      to: z.string().datetime().optional(),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/events/frequency', params))),
+  );
+}

--- a/packages/mcp/src/tools/github.ts
+++ b/packages/mcp/src/tools/github.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import { apiGet, safe, ok } from '../client.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+export function registerGithubTools(server: McpServer) {
+  server.tool(
+    'github-repo-activity',
+    'All GitHub events for a specific repository. Filter by event type (push, pull_request, etc.) or time window.',
+    {
+      repoFullName: z.string().describe('e.g. "myorg/myrepo"'),
+      eventType: z.string().optional(),
+      since: z.string().datetime().optional(),
+      limit: z.number().int().positive().max(200).default(50),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/github/repo-activity', params))),
+  );
+
+  server.tool(
+    'github-actor-activity',
+    'All GitHub events attributed to a specific actor login across all monitored repositories.',
+    {
+      login: z.string().describe('GitHub username'),
+      since: z.string().datetime().optional(),
+      limit: z.number().int().positive().max(200).default(50),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/github/actor-activity', params))),
+  );
+
+  server.tool(
+    'github-installations',
+    'GitHub App installations for the org: app slug, target account, permissions granted, and webhook event subscriptions.',
+    {},
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async () => ok(await safe(() => apiGet('/api/github/installations'))),
+  );
+
+  server.tool(
+    'github-repos',
+    'Monitored GitHub repositories: visibility, default branch, archived status, last sync time.',
+    { search: z.string().optional().describe('Substring search on full_name') },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/github/repos', params))),
+  );
+}

--- a/packages/mcp/src/tools/infra.ts
+++ b/packages/mcp/src/tools/infra.ts
@@ -1,0 +1,140 @@
+import { z } from 'zod';
+import { apiGet, apiPost, safe, ok } from '../client.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+export function registerInfraTools(server: McpServer) {
+  server.tool(
+    'infra-list-hosts',
+    'List all monitored infrastructure hosts for the org. Optional substring search on hostname.',
+    {
+      search: z.string().optional(),
+      isRoot: z.enum(['true', 'false']).optional(),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/infra/hosts', params))),
+  );
+
+  server.tool(
+    'infra-lookup-host',
+    'Full host intelligence: IP address, cloud provider, ASN, open ports, CDN origin records, DNS records, and last scan time. Use this to answer "what server is <hostname> on?"',
+    { hostname: z.string().describe('Hostname to look up, e.g. "aztec-labs.com"') },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async ({ hostname }) => ok(await safe(() => apiGet(`/api/infra/hosts/${encodeURIComponent(hostname)}`))),
+  );
+
+  server.tool(
+    'infra-get-origin',
+    'Return all CDN origin records for a host. Answers "what is the real server behind the CDN for <hostname>?"',
+    { hostname: z.string() },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async ({ hostname }) => ok(await safe(() => apiGet(`/api/infra/hosts/${encodeURIComponent(hostname)}/origin`))),
+  );
+
+  server.tool(
+    'infra-dns-history',
+    'DNS change log for a host: add/modify/remove events per record type.',
+    {
+      hostname: z.string(),
+      since: z.string().datetime().optional(),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async ({ hostname, since }) => ok(await safe(() => apiGet(`/api/infra/hosts/${encodeURIComponent(hostname)}/dns-history`, { since }))),
+  );
+
+  server.tool(
+    'infra-cert-expiry-report',
+    'Report of TLS certificates expiring within N days (default 30). Returns hostname, subject, issuer, and expiry date.',
+    { daysAhead: z.number().int().positive().default(30) },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/infra/cert-expiry', params))),
+  );
+
+  server.tool(
+    'infra-tls-analysis',
+    'Latest TLS analysis for a host: TLS versions supported, cipher suites, weak cipher flag.',
+    { hostname: z.string() },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async ({ hostname }) => ok(await safe(() => apiGet(`/api/infra/hosts/${encodeURIComponent(hostname)}/tls`))),
+  );
+
+  server.tool(
+    'infra-whois',
+    'Latest WHOIS record for a host: registrar, registration/expiry dates, name servers, EPP status.',
+    { hostname: z.string() },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async ({ hostname }) => ok(await safe(() => apiGet(`/api/infra/hosts/${encodeURIComponent(hostname)}/whois`))),
+  );
+
+  server.tool(
+    'infra-security-score',
+    'Security score history for a host with category breakdown and deduction reasons.',
+    {
+      hostname: z.string(),
+      limit: z.number().int().positive().max(90).default(30),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async ({ hostname, limit }) => ok(await safe(() => apiGet(`/api/infra/hosts/${encodeURIComponent(hostname)}/score`, { limit }))),
+  );
+
+  server.tool(
+    'infra-add-host',
+    'Add a new infrastructure host for monitoring. Hostname must be a valid domain (not a TLD). Enqueues an initial full scan immediately.',
+    {
+      hostname: z.string().min(1).max(253).describe('Domain to monitor, e.g. "app.example.com"'),
+      scanIntervalMinutes: z.number().int().min(5).default(1440).describe('Scan interval in minutes (default 24h)'),
+      probeEnabled: z.boolean().default(false).describe('Enable uptime probing'),
+      probeIntervalMinutes: z.number().int().min(1).default(5),
+    },
+    { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    async (body) => ok(await safe(() => apiPost('/api/infra/hosts', body))),
+  );
+
+  server.tool(
+    'infra-trigger-scan',
+    'Trigger an immediate full scan for a monitored host. Returns a job ID for tracking.',
+    { id: z.string().uuid().describe('Host UUID') },
+    { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    async ({ id }) => ok(await safe(() => apiPost(`/api/infra/hosts/${id}/scan`, {}))),
+  );
+
+  // --- Experimental: task-based variant of infra-trigger-scan ---
+  server.experimental.tasks.registerToolTask(
+    'infra-trigger-scan-task',
+    {
+      description:
+        'Long-running variant of infra-trigger-scan. Triggers a full host scan and polls until completion. Returns the scan result when finished.',
+      inputSchema: { id: z.string().uuid().describe('Host UUID') },
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+      execution: { taskSupport: 'required' },
+    },
+    {
+      createTask: async ({ id }, extra) => {
+        const task = await extra.taskStore.createTask({ ttl: 300_000, pollInterval: 5_000 });
+
+        // Fire the scan in the background and store result when done
+        (async () => {
+          try {
+            const result = await safe(() => apiPost(`/api/infra/hosts/${id}/scan`, {}));
+            await extra.taskStore.storeTaskResult(task.taskId, 'completed', {
+              content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+            });
+          } catch (err) {
+            await extra.taskStore.storeTaskResult(task.taskId, 'failed', {
+              content: [{ type: 'text' as const, text: `Scan failed: ${String(err)}` }],
+              isError: true,
+            });
+          }
+        })();
+
+        return { task };
+      },
+      getTask: async (_args, extra) => {
+        return await extra.taskStore.getTask(extra.taskId);
+      },
+      getTaskResult: async (_args, extra) => {
+        return (await extra.taskStore.getTaskResult(extra.taskId)) as CallToolResult;
+      },
+    },
+  );
+}

--- a/packages/mcp/src/tools/modules.ts
+++ b/packages/mcp/src/tools/modules.ts
@@ -1,0 +1,87 @@
+import { z } from 'zod';
+import { apiGet, safe, ok } from '../client.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+export function registerModuleTools(server: McpServer) {
+  server.tool(
+    'list-modules-and-event-types',
+    'List all Sentinel modules and their registered event types, evaluators, and template slugs.',
+    {},
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async () => ok(await safe(() => apiGet('/api/modules/metadata'))),
+  );
+
+  server.tool(
+    'get-sample-event-fields',
+    'Inspect the most recent event of a given moduleId+eventType and return the top-level payload field names with sample values. Useful before writing an event-search-payload query.',
+    {
+      moduleId: z.string(),
+      eventType: z.string(),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/events', { ...params, limit: 1 }))),
+  );
+
+  server.tool(
+    'resolve-detection-template',
+    'Look up available detection templates for a module, showing slug, name, description, required inputs, and default severity.',
+    {
+      moduleId: z.string().describe('chain | infra | aws | registry | github'),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/modules/metadata', params))),
+  );
+
+  server.tool(
+    'browse-field-catalog',
+    'Browse discovered field paths across events and alerts. Useful for understanding available payload fields before writing detection rules or searches.',
+    {
+      source: z.enum(['events', 'alerts']).optional(),
+      sourceType: z.string().optional().describe('e.g. specific eventType or alert type'),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/field-catalog', params))),
+  );
+
+  // --- Experimental: task-based variant of resolve-detection-template ---
+  server.experimental.tasks.registerToolTask(
+    'resolve-detection-template-task',
+    {
+      description:
+        'Long-running variant of resolve-detection-template. Fetches and resolves module templates, which may involve network calls to fetch remote template definitions.',
+      inputSchema: {
+        moduleId: z.string().describe('chain | infra | aws | registry | github'),
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+      execution: { taskSupport: 'required' },
+    },
+    {
+      createTask: async ({ moduleId }, extra) => {
+        const task = await extra.taskStore.createTask({ ttl: 120_000, pollInterval: 3_000 });
+
+        (async () => {
+          try {
+            const result = await safe(() => apiGet('/api/modules/metadata', { moduleId }));
+            await extra.taskStore.storeTaskResult(task.taskId, 'completed', {
+              content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+            });
+          } catch (err) {
+            await extra.taskStore.storeTaskResult(task.taskId, 'failed', {
+              content: [{ type: 'text' as const, text: `Template resolution failed: ${String(err)}` }],
+              isError: true,
+            });
+          }
+        })();
+
+        return { task };
+      },
+      getTask: async (_args, extra) => {
+        return await extra.taskStore.getTask(extra.taskId);
+      },
+      getTaskResult: async (_args, extra) => {
+        return (await extra.taskStore.getTaskResult(extra.taskId)) as CallToolResult;
+      },
+    },
+  );
+}

--- a/packages/mcp/src/tools/notifications.ts
+++ b/packages/mcp/src/tools/notifications.ts
@@ -1,0 +1,87 @@
+import { z } from 'zod';
+import { apiGet, apiPost, apiPatch, safe, ok } from '../client.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+export function registerNotificationTools(server: McpServer) {
+  server.tool(
+    'list-notification-deliveries',
+    'List notification deliveries. Filter by alertId, channelType, status, or date range.',
+    {
+      alertId: z.string().optional(),
+      channelType: z.string().optional().describe('slack | email | webhook | pagerduty'),
+      status: z.enum(['pending', 'sent', 'failed']).optional(),
+      from: z.string().datetime().optional(),
+      to: z.string().datetime().optional(),
+      page: z.number().int().positive().default(1),
+      limit: z.number().int().positive().max(100).default(20),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/notification-deliveries', params))),
+  );
+
+  server.tool(
+    'get-delivery-stats',
+    'Notification delivery statistics: success/failure counts by channel type, recent error samples.',
+    {
+      from: z.string().datetime().optional(),
+      to: z.string().datetime().optional(),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/notification-deliveries/stats', params))),
+  );
+
+  // --- Notification Channels ---
+
+  server.tool(
+    'list-channels',
+    'List all notification channels (email, webhook, Slack). Filter by type.',
+    {
+      type: z.enum(['email', 'webhook', 'slack']).optional(),
+      limit: z.number().int().min(1).max(100).default(50),
+      offset: z.number().int().min(0).default(0),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/channels', params))),
+  );
+
+  server.tool(
+    'get-channel',
+    'Get a notification channel by ID with full configuration.',
+    { id: z.string().uuid() },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async ({ id }) => ok(await safe(() => apiGet(`/api/channels/${id}`))),
+  );
+
+  server.tool(
+    'create-channel',
+    'Create a notification channel. Config varies by type: email needs {recipients: string[]}, webhook needs {url, secret?, headers?}, slack needs {channelId}.',
+    {
+      name: z.string().min(1).max(255),
+      type: z.enum(['email', 'webhook', 'slack']),
+      config: z.record(z.string(), z.unknown()).describe('Type-specific config: {recipients} for email, {url, secret?, headers?} for webhook, {channelId} for slack'),
+    },
+    { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    async (body) => ok(await safe(() => apiPost('/api/channels', body))),
+  );
+
+  server.tool(
+    'update-channel',
+    'Update a notification channel: name, config, or enabled status.',
+    {
+      id: z.string().uuid(),
+      name: z.string().min(1).max(255).optional(),
+      config: z.record(z.string(), z.unknown()).optional(),
+      enabled: z.boolean().optional(),
+    },
+    { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    async ({ id, ...body }) => ok(await safe(() => apiPatch(`/api/channels/${id}`, body))),
+  );
+
+  server.tool(
+    'test-channel',
+    'Send a test notification to a channel to verify connectivity.',
+    { id: z.string().uuid() },
+    { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    async ({ id }) => ok(await safe(() => apiPost(`/api/channels/${id}/test`, {}))),
+  );
+}

--- a/packages/mcp/src/tools/registry.ts
+++ b/packages/mcp/src/tools/registry.ts
@@ -1,0 +1,84 @@
+import { z } from 'zod';
+import { apiGet, apiPost, safe, ok } from '../client.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+export function registerRegistryTools(server: McpServer) {
+  server.tool(
+    'registry-artifact-summary',
+    'List all monitored artifacts (Docker images + npm packages) with active tag count and last push date.',
+    {},
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async () => ok(await safe(() => apiGet('/api/registry/artifacts/summary'))),
+  );
+
+  server.tool(
+    'registry-digest-history',
+    'Digest change log for an artifact: when each tag\'s image was replaced, with old/new digest and pusher.',
+    {
+      artifactName: z.string().describe('e.g. "myorg/myapp" or "@scope/pkg"'),
+      tag: z.string().optional().describe('Filter to a specific tag, e.g. "latest"'),
+      limit: z.number().int().positive().max(200).default(50),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/registry/digest-history', params))),
+  );
+
+  server.tool(
+    'registry-attribution-report',
+    'Attribution status breakdown: which artifact changes were verified to CI, inferred, suspicious, or unattributed.',
+    {
+      artifactName: z.string().optional(),
+      limit: z.number().int().positive().max(200).default(50),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/registry/attribution-report', params))),
+  );
+
+  server.tool(
+    'registry-unsigned-releases',
+    'List active artifact versions lacking cosign signature or SLSA provenance. Use for supply chain security audits.',
+    { artifactName: z.string().optional() },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/registry/unsigned-releases', params))),
+  );
+
+  server.tool(
+    'registry-ci-notifications',
+    'Recent CI pipeline push notifications: what digest each workflow claimed to produce, and whether it matched the observed digest.',
+    {
+      since: z.string().datetime().optional(),
+      limit: z.number().int().positive().max(200).default(50),
+    },
+    { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    async (params) => ok(await safe(() => apiGet('/api/registry/ci-notifications', params))),
+  );
+
+  server.tool(
+    'registry-add-image',
+    'Add a Docker image for monitoring. Tracks tag digests, attribution, and signature status.',
+    {
+      name: z.string().min(1).describe('Image name, e.g. "library/nginx" or "myorg/myapp"'),
+      tagPatterns: z.array(z.string()).default(['*']).describe('Glob patterns for tags to watch'),
+      ignorePatterns: z.array(z.string()).default([]),
+      pollIntervalSeconds: z.number().int().min(60).default(300),
+      githubRepo: z.string().regex(/^[^/]+\/[^/]+$/).optional().describe('Linked GitHub repo for CI attribution, e.g. "myorg/myrepo"'),
+    },
+    { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    async (body) => ok(await safe(() => apiPost('/api/registry/images', body))),
+  );
+
+  server.tool(
+    'registry-add-package',
+    'Add an npm package for monitoring. Tracks version digests, attribution, and signature status.',
+    {
+      name: z.string().min(1).describe('Package name, e.g. "@acme/sdk" or "lodash"'),
+      tagPatterns: z.array(z.string()).default(['*']).describe('Glob patterns for dist-tags/versions to watch'),
+      ignorePatterns: z.array(z.string()).default([]),
+      pollIntervalSeconds: z.number().int().min(60).default(300),
+      githubRepo: z.string().regex(/^[^/]+\/[^/]+$/).optional().describe('Linked GitHub repo for CI attribution'),
+      watchMode: z.enum(['dist-tags', 'versions']).default('versions'),
+    },
+    { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    async (body) => ok(await safe(() => apiPost('/api/registry/packages', body))),
+  );
+}

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/node@22.19.15)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+        version: 3.2.4(vitest@3.2.4(@types/node@22.19.17)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
       argon2:
         specifier: ^0.44.0
         version: 0.44.0
@@ -32,7 +32,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@22.19.15)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.17)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
 
   apps/api:
     dependencies:
@@ -414,8 +414,8 @@ importers:
   packages/db:
     dependencies:
       drizzle-orm:
-        specifier: ^0.38.0
-        version: 0.38.4(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(@types/react@19.2.14)(postgres@3.4.8)(react@19.2.4)
+        specifier: ^0.45.2
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(gel@2.2.0)(postgres@3.4.8)
       postgres:
         specifier: ^3.4.5
         version: 3.4.8
@@ -424,8 +424,8 @@ importers:
         specifier: ^22.0.0
         version: 22.19.15
       drizzle-kit:
-        specifier: ^0.30.0
-        version: 0.30.6
+        specifier: ^0.31.0
+        version: 0.31.10
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
@@ -795,9 +795,9 @@ packages:
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
     deprecated: 'Merged into tsx: https://tsx.is'
 
-  '@esbuild/aix-ppc64@0.19.12':
-    resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
-    engines: {node: '>=12'}
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
@@ -813,9 +813,9 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.19.12':
-    resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==}
-    engines: {node: '>=12'}
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -831,9 +831,9 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.19.12':
-    resolution: {integrity: sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==}
-    engines: {node: '>=12'}
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
@@ -849,9 +849,9 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.19.12':
-    resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==}
-    engines: {node: '>=12'}
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -867,9 +867,9 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.19.12':
-    resolution: {integrity: sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==}
-    engines: {node: '>=12'}
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
@@ -885,9 +885,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.19.12':
-    resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==}
-    engines: {node: '>=12'}
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -903,9 +903,9 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.19.12':
-    resolution: {integrity: sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==}
-    engines: {node: '>=12'}
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
@@ -921,9 +921,9 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.19.12':
-    resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==}
-    engines: {node: '>=12'}
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -939,9 +939,9 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.19.12':
-    resolution: {integrity: sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
@@ -957,9 +957,9 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.19.12':
-    resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -975,9 +975,9 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.19.12':
-    resolution: {integrity: sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
@@ -993,9 +993,9 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.19.12':
-    resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -1011,9 +1011,9 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.19.12':
-    resolution: {integrity: sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
@@ -1029,9 +1029,9 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.19.12':
-    resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -1047,9 +1047,9 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.19.12':
-    resolution: {integrity: sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
@@ -1065,9 +1065,9 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.19.12':
-    resolution: {integrity: sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -1083,9 +1083,9 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.19.12':
-    resolution: {integrity: sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
@@ -1094,6 +1094,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
 
   '@esbuild/netbsd-arm64@0.27.4':
     resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
@@ -1107,9 +1113,9 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.19.12':
-    resolution: {integrity: sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==}
-    engines: {node: '>=12'}
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
@@ -1118,6 +1124,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-arm64@0.27.4':
     resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
@@ -1131,9 +1143,9 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.19.12':
-    resolution: {integrity: sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==}
-    engines: {node: '>=12'}
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
@@ -1142,6 +1154,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
 
   '@esbuild/openharmony-arm64@0.27.4':
     resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
@@ -1155,9 +1173,9 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.19.12':
-    resolution: {integrity: sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==}
-    engines: {node: '>=12'}
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -1173,9 +1191,9 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.19.12':
-    resolution: {integrity: sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
@@ -1191,9 +1209,9 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.19.12':
-    resolution: {integrity: sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
@@ -1209,9 +1227,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/win32-x64@0.19.12':
-    resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -2644,6 +2662,9 @@ packages:
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
   '@types/nodemailer@6.4.23':
     resolution: {integrity: sha512-aFV3/NsYFLSx9mbb5gtirBSXJnAlrusoKNuPbxsASWc7vrKLmIrTQRpdcxNcSFL3VW2A2XpeLEavwb2qMi6nlQ==}
 
@@ -3102,6 +3123,11 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  baseline-browser-mapping@2.10.17:
+    resolution: {integrity: sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -3132,6 +3158,11 @@ packages:
 
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -3175,6 +3206,9 @@ packages:
 
   caniuse-lite@1.0.30001781:
     resolution: {integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==}
+
+  caniuse-lite@1.0.30001787:
+    resolution: {integrity: sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -3377,12 +3411,12 @@ packages:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
 
-  drizzle-kit@0.30.6:
-    resolution: {integrity: sha512-U4wWit0fyZuGuP7iNmRleQyK2V8wCuv57vf5l3MnG4z4fzNTjY/U13M8owyQ5RavqvqxBifWORaR3wIUzlN64g==}
+  drizzle-kit@0.31.10:
+    resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
     hasBin: true
 
-  drizzle-orm@0.38.4:
-    resolution: {integrity: sha512-s7/5BpLKO+WJRHspvpqTydxFob8i1vo2rEx4pY6TGY7QSMuUfWUuzaY0DIpXCkgHOo37BaFC+SJQb99dDUXT3Q==}
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -3392,25 +3426,25 @@ packages:
       '@neondatabase/serverless': '>=0.10.0'
       '@op-engineering/op-sqlite': '>=2'
       '@opentelemetry/api': ^1.4.1
-      '@planetscale/database': '>=1'
+      '@planetscale/database': '>=1.13'
       '@prisma/client': '*'
       '@tidbcloud/serverless': '*'
       '@types/better-sqlite3': '*'
       '@types/pg': '*'
-      '@types/react': '>=18'
       '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
       '@vercel/postgres': '>=0.8.0'
       '@xata.io/client': '*'
       better-sqlite3: '>=7'
       bun-types: '*'
       expo-sqlite: '>=14.0.0'
+      gel: '>=2'
       knex: '*'
       kysely: '*'
       mysql2: '>=2'
       pg: '>=8'
       postgres: '>=3'
       prisma: '*'
-      react: '>=18'
       sql.js: '>=1'
       sqlite3: '>=5'
     peerDependenciesMeta:
@@ -3440,9 +3474,9 @@ packages:
         optional: true
       '@types/pg':
         optional: true
-      '@types/react':
-        optional: true
       '@types/sql.js':
+        optional: true
+      '@upstash/redis':
         optional: true
       '@vercel/postgres':
         optional: true
@@ -3453,6 +3487,8 @@ packages:
       bun-types:
         optional: true
       expo-sqlite:
+        optional: true
+      gel:
         optional: true
       knex:
         optional: true
@@ -3465,8 +3501,6 @@ packages:
       postgres:
         optional: true
       prisma:
-        optional: true
-      react:
         optional: true
       sql.js:
         optional: true
@@ -3485,6 +3519,9 @@ packages:
 
   electron-to-chromium@1.5.328:
     resolution: {integrity: sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==}
+
+  electron-to-chromium@1.5.334:
+    resolution: {integrity: sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -3551,19 +3588,14 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
-  esbuild-register@3.6.0:
-    resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
-    peerDependencies:
-      esbuild: '>=0.12 <1'
-
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
     engines: {node: '>=12'}
     hasBin: true
 
-  esbuild@0.19.12:
-    resolution: {integrity: sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==}
-    engines: {node: '>=12'}
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
     hasBin: true
 
   esbuild@0.27.4:
@@ -4545,6 +4577,9 @@ packages:
 
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
+
+  node-releases@2.0.37:
+    resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
   nodemailer@8.0.4:
     resolution: {integrity: sha512-k+jf6N8PfQJ0Fe8ZhJlgqU5qJU44Lpvp2yvidH3vp1lPnVQMgi4yEEMPXg5eJS1gFIJTVq1NHBk7Ia9ARdSBdQ==}
@@ -6351,7 +6386,7 @@ snapshots:
       '@esbuild-kit/core-utils': 3.3.2
       get-tsconfig: 4.13.7
 
-  '@esbuild/aix-ppc64@0.19.12':
+  '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
   '@esbuild/aix-ppc64@0.27.4':
@@ -6360,7 +6395,7 @@ snapshots:
   '@esbuild/android-arm64@0.18.20':
     optional: true
 
-  '@esbuild/android-arm64@0.19.12':
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.4':
@@ -6369,7 +6404,7 @@ snapshots:
   '@esbuild/android-arm@0.18.20':
     optional: true
 
-  '@esbuild/android-arm@0.19.12':
+  '@esbuild/android-arm@0.25.12':
     optional: true
 
   '@esbuild/android-arm@0.27.4':
@@ -6378,7 +6413,7 @@ snapshots:
   '@esbuild/android-x64@0.18.20':
     optional: true
 
-  '@esbuild/android-x64@0.19.12':
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.4':
@@ -6387,7 +6422,7 @@ snapshots:
   '@esbuild/darwin-arm64@0.18.20':
     optional: true
 
-  '@esbuild/darwin-arm64@0.19.12':
+  '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.4':
@@ -6396,7 +6431,7 @@ snapshots:
   '@esbuild/darwin-x64@0.18.20':
     optional: true
 
-  '@esbuild/darwin-x64@0.19.12':
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.4':
@@ -6405,7 +6440,7 @@ snapshots:
   '@esbuild/freebsd-arm64@0.18.20':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.19.12':
+  '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.4':
@@ -6414,7 +6449,7 @@ snapshots:
   '@esbuild/freebsd-x64@0.18.20':
     optional: true
 
-  '@esbuild/freebsd-x64@0.19.12':
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.4':
@@ -6423,7 +6458,7 @@ snapshots:
   '@esbuild/linux-arm64@0.18.20':
     optional: true
 
-  '@esbuild/linux-arm64@0.19.12':
+  '@esbuild/linux-arm64@0.25.12':
     optional: true
 
   '@esbuild/linux-arm64@0.27.4':
@@ -6432,7 +6467,7 @@ snapshots:
   '@esbuild/linux-arm@0.18.20':
     optional: true
 
-  '@esbuild/linux-arm@0.19.12':
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.4':
@@ -6441,7 +6476,7 @@ snapshots:
   '@esbuild/linux-ia32@0.18.20':
     optional: true
 
-  '@esbuild/linux-ia32@0.19.12':
+  '@esbuild/linux-ia32@0.25.12':
     optional: true
 
   '@esbuild/linux-ia32@0.27.4':
@@ -6450,7 +6485,7 @@ snapshots:
   '@esbuild/linux-loong64@0.18.20':
     optional: true
 
-  '@esbuild/linux-loong64@0.19.12':
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.4':
@@ -6459,7 +6494,7 @@ snapshots:
   '@esbuild/linux-mips64el@0.18.20':
     optional: true
 
-  '@esbuild/linux-mips64el@0.19.12':
+  '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.4':
@@ -6468,7 +6503,7 @@ snapshots:
   '@esbuild/linux-ppc64@0.18.20':
     optional: true
 
-  '@esbuild/linux-ppc64@0.19.12':
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.4':
@@ -6477,7 +6512,7 @@ snapshots:
   '@esbuild/linux-riscv64@0.18.20':
     optional: true
 
-  '@esbuild/linux-riscv64@0.19.12':
+  '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.4':
@@ -6486,7 +6521,7 @@ snapshots:
   '@esbuild/linux-s390x@0.18.20':
     optional: true
 
-  '@esbuild/linux-s390x@0.19.12':
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.4':
@@ -6495,10 +6530,13 @@ snapshots:
   '@esbuild/linux-x64@0.18.20':
     optional: true
 
-  '@esbuild/linux-x64@0.19.12':
+  '@esbuild/linux-x64@0.25.12':
     optional: true
 
   '@esbuild/linux-x64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.4':
@@ -6507,10 +6545,13 @@ snapshots:
   '@esbuild/netbsd-x64@0.18.20':
     optional: true
 
-  '@esbuild/netbsd-x64@0.19.12':
+  '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.4':
@@ -6519,10 +6560,13 @@ snapshots:
   '@esbuild/openbsd-x64@0.18.20':
     optional: true
 
-  '@esbuild/openbsd-x64@0.19.12':
+  '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.4':
@@ -6531,7 +6575,7 @@ snapshots:
   '@esbuild/sunos-x64@0.18.20':
     optional: true
 
-  '@esbuild/sunos-x64@0.19.12':
+  '@esbuild/sunos-x64@0.25.12':
     optional: true
 
   '@esbuild/sunos-x64@0.27.4':
@@ -6540,7 +6584,7 @@ snapshots:
   '@esbuild/win32-arm64@0.18.20':
     optional: true
 
-  '@esbuild/win32-arm64@0.19.12':
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.4':
@@ -6549,7 +6593,7 @@ snapshots:
   '@esbuild/win32-ia32@0.18.20':
     optional: true
 
-  '@esbuild/win32-ia32@0.19.12':
+  '@esbuild/win32-ia32@0.25.12':
     optional: true
 
   '@esbuild/win32-ia32@0.27.4':
@@ -6558,7 +6602,7 @@ snapshots:
   '@esbuild/win32-x64@0.18.20':
     optional: true
 
-  '@esbuild/win32-x64@0.19.12':
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.4':
@@ -7412,7 +7456,8 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@petamoriken/float16@3.9.3': {}
+  '@petamoriken/float16@3.9.3':
+    optional: true
 
   '@phc/format@1.0.0': {}
 
@@ -8201,6 +8246,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/nodemailer@6.4.23':
     dependencies:
       '@types/node': 22.19.15
@@ -8389,7 +8438,7 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@22.19.15)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@22.19.17)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -8404,7 +8453,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@22.19.15)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
+      vitest: 3.2.4(@types/node@22.19.17)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8416,13 +8465,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.17)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.15)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@22.19.17)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -8719,6 +8768,8 @@ snapshots:
 
   baseline-browser-mapping@2.10.12: {}
 
+  baseline-browser-mapping@2.10.17: {}
+
   binary-extensions@2.3.0: {}
 
   bintrees@1.0.2: {}
@@ -8763,6 +8814,14 @@ snapshots:
       electron-to-chromium: 1.5.328
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.17
+      caniuse-lite: 1.0.30001787
+      electron-to-chromium: 1.5.334
+      node-releases: 2.0.37
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   buffer-from@1.1.2: {}
 
@@ -8819,6 +8878,8 @@ snapshots:
   camelcase-css@2.0.1: {}
 
   caniuse-lite@1.0.30001781: {}
+
+  caniuse-lite@1.0.30001787: {}
 
   chai@5.3.3:
     dependencies:
@@ -8986,23 +9047,19 @@ snapshots:
 
   dotenv@16.6.1: {}
 
-  drizzle-kit@0.30.6:
+  drizzle-kit@0.31.10:
     dependencies:
       '@drizzle-team/brocli': 0.10.2
       '@esbuild-kit/esm-loader': 2.6.5
-      esbuild: 0.19.12
-      esbuild-register: 3.6.0(esbuild@0.19.12)
-      gel: 2.2.0
-    transitivePeerDependencies:
-      - supports-color
+      esbuild: 0.25.12
+      tsx: 4.21.0
 
-  drizzle-orm@0.38.4(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(@types/react@19.2.14)(postgres@3.4.8)(react@19.2.4):
+  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(gel@2.2.0)(postgres@3.4.8):
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.15.6
-      '@types/react': 19.2.14
+      gel: 2.2.0
       postgres: 3.4.8
-      react: 19.2.4
 
   dunder-proto@1.0.1:
     dependencies:
@@ -9015,6 +9072,8 @@ snapshots:
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.328: {}
+
+  electron-to-chromium@1.5.334: {}
 
   emoji-regex@8.0.0: {}
 
@@ -9036,7 +9095,8 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.2
 
-  env-paths@3.0.0: {}
+  env-paths@3.0.0:
+    optional: true
 
   err-code@2.0.3: {}
 
@@ -9146,13 +9206,6 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
-  esbuild-register@3.6.0(esbuild@0.19.12):
-    dependencies:
-      debug: 4.4.3
-      esbuild: 0.19.12
-    transitivePeerDependencies:
-      - supports-color
-
   esbuild@0.18.20:
     optionalDependencies:
       '@esbuild/android-arm': 0.18.20
@@ -9178,31 +9231,34 @@ snapshots:
       '@esbuild/win32-ia32': 0.18.20
       '@esbuild/win32-x64': 0.18.20
 
-  esbuild@0.19.12:
+  esbuild@0.25.12:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.19.12
-      '@esbuild/android-arm': 0.19.12
-      '@esbuild/android-arm64': 0.19.12
-      '@esbuild/android-x64': 0.19.12
-      '@esbuild/darwin-arm64': 0.19.12
-      '@esbuild/darwin-x64': 0.19.12
-      '@esbuild/freebsd-arm64': 0.19.12
-      '@esbuild/freebsd-x64': 0.19.12
-      '@esbuild/linux-arm': 0.19.12
-      '@esbuild/linux-arm64': 0.19.12
-      '@esbuild/linux-ia32': 0.19.12
-      '@esbuild/linux-loong64': 0.19.12
-      '@esbuild/linux-mips64el': 0.19.12
-      '@esbuild/linux-ppc64': 0.19.12
-      '@esbuild/linux-riscv64': 0.19.12
-      '@esbuild/linux-s390x': 0.19.12
-      '@esbuild/linux-x64': 0.19.12
-      '@esbuild/netbsd-x64': 0.19.12
-      '@esbuild/openbsd-x64': 0.19.12
-      '@esbuild/sunos-x64': 0.19.12
-      '@esbuild/win32-arm64': 0.19.12
-      '@esbuild/win32-ia32': 0.19.12
-      '@esbuild/win32-x64': 0.19.12
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -9247,8 +9303,8 @@ snapshots:
       '@typescript-eslint/parser': 8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       eslint: 9.39.4(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.4(jiti@1.21.7))
@@ -9267,7 +9323,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -9278,22 +9334,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       eslint: 9.39.4(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9304,7 +9360,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -9636,6 +9692,7 @@ snapshots:
       which: 4.0.0
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   generator-function@2.0.1: {}
 
@@ -9973,7 +10030,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isexe@3.1.5: {}
+  isexe@3.1.5:
+    optional: true
 
   isows@1.0.7(ws@8.18.3):
     dependencies:
@@ -10017,7 +10075,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 22.19.17
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -10319,6 +10377,8 @@ snapshots:
   node-gyp-build@4.8.4: {}
 
   node-releases@2.0.36: {}
+
+  node-releases@2.0.37: {}
 
   nodemailer@8.0.4: {}
 
@@ -10897,7 +10957,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.3:
+    optional: true
 
   shimmer@1.2.1: {}
 
@@ -11343,6 +11404,12 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -11393,6 +11460,27 @@ snapshots:
       - tsx
       - yaml
 
+  vite-node@3.2.4(@types/node@22.19.17)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.1(@types/node@22.19.17)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.4
@@ -11408,11 +11496,26 @@ snapshots:
       terser: 5.46.1
       tsx: 4.21.0
 
+  vite@7.3.1(@types/node@22.19.17)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0):
+    dependencies:
+      esbuild: 0.27.4
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.8
+      rollup: 4.60.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      terser: 5.46.1
+      tsx: 4.21.0
+
   vitest@3.2.4(@types/node@22.19.15)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.15)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.17)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -11449,6 +11552,47 @@ snapshots:
       - tsx
       - yaml
 
+  vitest@3.2.4(@types/node@22.19.17)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.17)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.1(@types/node@22.19.17)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
+      vite-node: 3.2.4(@types/node@22.19.17)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   w3c-keyname@2.2.8: {}
 
   watchpack@2.5.1:
@@ -11470,7 +11614,7 @@ snapshots:
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.16.0
       acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.1
+      browserslist: 4.28.2
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.20.1
       es-module-lexer: 2.0.0
@@ -11545,6 +11689,7 @@ snapshots:
   which@4.0.0:
     dependencies:
       isexe: 3.1.5
+    optional: true
 
   why-is-node-running@2.3.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,6 +433,25 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.10.2
+        version: 1.29.0(zod@3.25.76)
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/notifications:
     dependencies:
       '@sentinel/shared':
@@ -1455,6 +1474,16 @@ packages:
 
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
@@ -2898,6 +2927,10 @@ packages:
       zod:
         optional: true
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-import-attributes@1.9.5:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
@@ -2933,6 +2966,14 @@ packages:
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
       ajv: ^8.0.0
     peerDependenciesMeta:
@@ -3068,6 +3109,10 @@ packages:
   bintrees@1.0.2:
     resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
@@ -3095,6 +3140,10 @@ packages:
 
   bullmq@5.71.1:
     resolution: {integrity: sha512-kOBfdcsHmO6wwmIjpersoVdYQ7jkjTgky4Yop0loc7QwSdgxliSzD69U9ijZuRrkyCJwz5p5eqxeGeQkJ0YGZQ==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -3205,8 +3254,28 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
@@ -3285,6 +3354,10 @@ packages:
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -3407,6 +3480,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   electron-to-chromium@1.5.328:
     resolution: {integrity: sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==}
 
@@ -3415,6 +3491,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   encoding@0.1.13:
     resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
@@ -3494,6 +3574,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -3633,6 +3716,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
@@ -3640,9 +3727,27 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.3.2:
+    resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   fast-copy@4.0.2:
     resolution: {integrity: sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==}
@@ -3705,6 +3810,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -3735,6 +3844,14 @@ packages:
 
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-minipass@3.0.3:
     resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
@@ -3858,6 +3975,10 @@ packages:
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -3872,6 +3993,10 @@ packages:
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
@@ -3904,6 +4029,9 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
@@ -3922,6 +4050,10 @@ packages:
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -4000,6 +4132,9 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
@@ -4086,6 +4221,9 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -4122,6 +4260,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -4224,9 +4365,17 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   memorystream@0.3.1:
     resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
     engines: {node: '>= 0.10.0'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -4243,9 +4392,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
@@ -4328,6 +4485,10 @@ packages:
 
   negotiator@0.6.4:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
+    engines: {node: '>= 0.6'}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
   neo-async@2.6.2:
@@ -4433,6 +4594,10 @@ packages:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
 
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -4475,6 +4640,10 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -4497,6 +4666,9 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -4551,6 +4723,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4653,6 +4829,10 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -4663,11 +4843,23 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
@@ -4761,6 +4953,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -4806,6 +5002,14 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -4817,6 +5021,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -4914,6 +5121,10 @@ packages:
 
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -5100,6 +5311,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
@@ -5134,6 +5349,10 @@ packages:
   type-fest@0.7.1:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
     engines: {node: '>=8'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -5171,6 +5390,10 @@ packages:
     resolution: {integrity: sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
@@ -5193,6 +5416,10 @@ packages:
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   viem@2.47.6:
     resolution: {integrity: sha512-zExmbI99NGvMdYa7fmqSTLgkwh48dmhgEqFrUgkpL4kfG4XkVefZ8dZqIKVUhZo6Uhf0FrrEXOsHm9LUyIvI2Q==}
@@ -5377,6 +5604,11 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -6560,6 +6792,28 @@ snapshots:
       '@lezer/common': 1.5.1
 
   '@marijn/find-cluster-break@1.0.2': {}
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.11(hono@4.12.9)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.2(express@5.2.1)
+      hono: 4.12.9
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
@@ -8281,6 +8535,11 @@ snapshots:
       typescript: 5.9.3
       zod: 3.25.76
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-import-attributes@1.9.5(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -8309,6 +8568,10 @@ snapshots:
       indent-string: 4.0.0
 
   ajv-formats@2.1.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
+  ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
 
@@ -8460,6 +8723,20 @@ snapshots:
 
   bintrees@1.0.2: {}
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   bowser@2.14.1: {}
 
   brace-expansion@1.1.13:
@@ -8500,6 +8777,8 @@ snapshots:
       uuid: 11.1.0
     transitivePeerDependencies:
       - supports-color
+
+  bytes@3.1.2: {}
 
   cac@6.7.14: {}
 
@@ -8608,7 +8887,20 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   crelt@1.0.6: {}
 
@@ -8679,6 +8971,8 @@ snapshots:
 
   denque@2.1.0: {}
 
+  depd@2.0.0: {}
+
   detect-libc@2.1.2:
     optional: true
 
@@ -8718,11 +9012,15 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
+  ee-first@1.1.1: {}
+
   electron-to-chromium@1.5.328: {}
 
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  encodeurl@2.0.0: {}
 
   encoding@0.1.13:
     dependencies:
@@ -8937,6 +9235,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@4.0.0: {}
 
   eslint-config-next@15.5.14(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3):
@@ -9150,11 +9450,57 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   eventemitter3@5.0.1: {}
 
   events@3.3.0: {}
 
+  eventsource-parser@3.0.6: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.3.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   fast-copy@4.0.2: {}
 
@@ -9220,6 +9566,17 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -9244,6 +9601,10 @@ snapshots:
       signal-exit: 4.1.0
 
   forwarded-parse@2.1.2: {}
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   fs-minipass@3.0.3:
     dependencies:
@@ -9374,6 +9735,14 @@ snapshots:
 
   http-cache-semantics@4.2.0: {}
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -9399,6 +9768,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
     optional: true
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
@@ -9434,6 +9807,8 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  inherits@2.0.4: {}
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -9465,6 +9840,8 @@ snapshots:
       - supports-color
 
   ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -9546,6 +9923,8 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
+
+  is-promise@4.0.0: {}
 
   is-reference@1.2.1:
     dependencies:
@@ -9644,6 +10023,8 @@ snapshots:
 
   jiti@1.21.7: {}
 
+  jose@6.2.2: {}
+
   joycon@3.1.1: {}
 
   js-sha3@0.8.0: {}
@@ -9667,6 +10048,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -9769,7 +10152,11 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  media-typer@1.1.0: {}
+
   memorystream@0.3.1: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -9782,9 +10169,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   minimatch@10.2.4:
     dependencies:
@@ -9872,6 +10265,8 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@0.6.4: {}
+
+  negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
 
@@ -9975,6 +10370,10 @@ snapshots:
 
   on-exit-leak-free@2.1.2: {}
 
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -10029,6 +10428,8 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-expression-matcher@1.2.0: {}
@@ -10046,6 +10447,8 @@ snapshots:
     dependencies:
       lru-cache: 11.2.7
       minipass: 7.1.3
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -10112,6 +10515,8 @@ snapshots:
       thread-stream: 3.1.0
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -10195,6 +10600,11 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   proxy-from-env@1.1.0: {}
 
   pump@3.0.4:
@@ -10204,9 +10614,22 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
   queue-microtask@1.2.3: {}
 
   quick-format-unescaped@4.0.4: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:
@@ -10333,6 +10756,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.0
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -10358,8 +10791,7 @@ snapshots:
 
   safe-stable-stringify@2.5.0: {}
 
-  safer-buffer@2.1.2:
-    optional: true
+  safer-buffer@2.1.2: {}
 
   scheduler@0.27.0: {}
 
@@ -10377,6 +10809,31 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   set-function-length@1.2.2:
     dependencies:
@@ -10399,6 +10856,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -10531,6 +10990,8 @@ snapshots:
       type-fest: 0.7.1
 
   standard-as-callback@2.1.0: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -10752,6 +11213,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   tr46@0.0.3: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
@@ -10789,6 +11252,12 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-fest@0.7.1: {}
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -10842,6 +11311,8 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
 
+  unpipe@1.0.0: {}
+
   unrs-resolver@1.11.1:
     dependencies:
       napi-postinstall: 0.3.4
@@ -10881,6 +11352,8 @@ snapshots:
   uuid@11.1.0: {}
 
   uuid@9.0.1: {}
+
+  vary@1.1.2: {}
 
   viem@2.47.6(typescript@5.9.3)(zod@3.25.76):
     dependencies:
@@ -11105,5 +11578,9 @@ snapshots:
   yallist@5.0.0: {}
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}


### PR DESCRIPTION
… features

Add @sentinel/mcp as a workspace package — an MCP server that proxies the Sentinel API for use with Claude and other MCP-compatible clients.

- Streamable HTTP transport (alongside stdio) with session management and DNS rebinding protection
- OAuth 2.1 + PKCE auth for HTTP transport, simple Bearer fallback
- Server instructions describing investigation/detection/infra workflows
- Tool annotations (readOnly, destructive, idempotent, openWorld)
- Elicitation for destructive operations
- Experimental task support for long-running operations
- 65 tools, 8 resources, 7 prompts covering alerts, events, detections, correlation, notifications, infra, AWS, chain, registry, and GitHub